### PR TITLE
Add datagovuk-tech-docs to integration

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -88,6 +88,19 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/ssl-redirect: "443"
       tls:
         enabled: true
+  techdocs:
+    replicaCount: 1
+    ingress:
+      enabled: true
+      host: datagovuk-docs.eks.integration.govuk.digital
+      ingressClassName: aws-alb
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/ssl-redirect: "443"
+      tls:
+        enabled: true
   opensearch:
     replicaCount: 1
   externalSecret:

--- a/charts/app-of-apps/values.yaml
+++ b/charts/app-of-apps/values.yaml
@@ -14,3 +14,5 @@ datagovukHelmValues:
 
   opensearch:
     replicaCount: 1
+  techDocs:
+    replicaCount: 1

--- a/charts/datagovuk/images/integration/techdocs.yaml
+++ b/charts/datagovuk/images/integration/techdocs.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/datagovuk-tech-docs
+tag: 2dd9493e0a534b5d070aed8ebd472793409b9988
+branch: main

--- a/charts/datagovuk/images/test/techdocs.yaml
+++ b/charts/datagovuk/images/test/techdocs.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/datagovuk-tech-docs
+tag: 2dd9493e0a534b5d070aed8ebd472793409b9988
+branch: main

--- a/charts/datagovuk/templates/techdocs/deployment.yaml
+++ b/charts/datagovuk/templates/techdocs/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-techdocs
+spec:
+  replicas: {{ .Values.techdocs.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-techdocs
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-techdocs
+    spec:
+      securityContext:
+        runAsUser: 900
+        runAsGroup: 900
+        fsGroup: 900
+      containers:
+        - name: techdocs
+          image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "techdocs" "files" $.Files) }}'
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 4567
+          command: ["/bin/sh", "-c"]
+          args: ["bundle exec middleman server"]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 60
+            timeoutSeconds: 30
+          volumeMounts:
+            - name: app-tmp
+              mountPath: /srv/app/datagovuk_tech_docs/tmp
+      volumes:
+        - name: app-tmp
+          emptyDir: {}

--- a/charts/datagovuk/templates/techdocs/ingress.yaml
+++ b/charts/datagovuk/templates/techdocs/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.techdocs.ingress.enabled }}
+{{- with .Values.techdocs.ingress }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: techdocs
+  {{- if not (empty .annotations) }}
+  annotations:
+    {{- toYaml .annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{ if not (empty .ingressClassName) }}ingressClassName: {{ .ingressClassName }}{{ end }}
+  rules:
+    - host: {{ .host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-techdocs
+                port:
+                  number: 4567
+  {{- if .tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .host }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/datagovuk/templates/techdocs/service.yaml
+++ b/charts/datagovuk/templates/techdocs/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-techdocs
+spec:
+  selector:
+    app: {{ .Release.Name }}-techdocs
+  ports:
+    - name: http
+      protocol: TCP
+      port: 4567
+      targetPort: http

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -56,6 +56,16 @@ find:
       name: datagovuk
       key: find_sentry_dsn
 
+techdocs:
+  replicaCount: 1
+  ingress:
+    enabled: true
+    host: techdocs.dev.govuk.digital
+    ingressClassName: ""
+    annotations:
+    tls:
+      enabled: false
+
 externalSecret:
   enabled: false
   name: datagovuk


### PR DESCRIPTION
Description:
- As part of the migration work away from GOV.UK PaaS to EKS we are moving the datagovuk-tech-docs app
- Add a Helm chart for the integration environment