### PR TITLE
Change find server.pid

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,11 @@ Add `ckan.dev.govuk.digital` after `kubernetes.docker.internal` on the sameline 
 
 In order to test the changes in EKS follow these steps:
 
-- disable the auto-sync in the `dgu-app-of-apps` application.
-  - edit the target revision to be the branch you want to test and manually sync it.
-- edit the revision of the branch to be the branch you want to test in the `ckan` applications (not in the `dgu-app-of-apps` space).
-  - you may need to delete the app that has been updated in order to pick up the change.
-- if you make further changes to the chart you may need to manually sync the `dgu-app-of-apps`.
-- if it is not syncing you may need to check the sync status and terminate any running processes.
-- after testing is complete remember to turn on the auto sync in `dgu-app-of-apps`.
+1. update the `targetRevision` in `ckan-application.yaml` or `datagovuk-application.yaml` to be the branch you want to test against.
+1. update the target revision in Argo on `dgu-app-of-apps` to be the branch you want to test, normally on the Integration cluster.
+1. carry out your testing.
+1. after testing is complete remember to set the target revision back to `main` in `dgu-app-of-apps`.
+1. if you are creating a PR drop the commit which updates the `targetRevision` in step 1.
 
 ### Github API token permissions
 

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -77,7 +77,7 @@ datagovukHelmValues:
         schedule: "*/10 * * * *"
   find:
     replicaCount: 1
-    args: ["bin/rails s -b 0.0.0.0"]
+    args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     ingress:
       host: find.eks.integration.govuk.digital
       ingressClassName: aws-alb

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -76,7 +76,7 @@ datagovukHelmValues:
         schedule: "*/10 * * * *"
   find:
     replicaCount: 2
-    args: [ "bin/rails s -b 0.0.0.0" ]
+    args: [ "bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid" ]
     ingress:
       host: find.eks.production.govuk.digital
       ingressClassName: aws-alb

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -78,7 +78,7 @@ datagovukHelmValues:
         schedule: "*/10 * * * *"
   find:
     replicaCount: 1
-    args: [ "bin/rails s -b 0.0.0.0" ]
+    args: [ "bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid" ]
     ingress:
       host: find.eks.staging.govuk.digital
       ingressClassName: aws-alb

--- a/charts/datagovuk/templates/_publish.tpl
+++ b/charts/datagovuk/templates/_publish.tpl
@@ -28,9 +28,6 @@
       name: {{ .sentryDsnSecretKeyRef.name }}
       key: {{ .sentryDsnSecretKeyRef.key }}
 - name: GOVUK_APP_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ .govukAppDomainSecretKeyRef.name }}
-      key: {{ .govukAppDomainSecretKeyRef.key }}
+  value: "www.gov.uk"
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -33,13 +33,3 @@ spec:
               port: http
             periodSeconds: 60
             timeoutSeconds: 30
-          volumeMounts:
-            - name: app-tmp
-              mountPath: /srv/app/datagovuk_find/tmp
-      volumes:
-        - name: app-tmp
-          emptyDir: {}
-        - name: find-init
-          configMap:
-            name: {{ .Release.Name }}-find-init
-

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -18,9 +18,6 @@ publish:
     sentryDsnSecretKeyRef:
       name: datagovuk
       key: publish_sentry_dsn
-    findUrlSecretKeyRef:
-      name: datagovuk
-      key: find_url
     govukAppDomainSecretKeyRef:
       name: datagovuk
       key: govuk_app_domain
@@ -33,7 +30,7 @@ publish:
 
 find:
   replicaCount: 1
-  args: ["bin/rails s -b 0.0.0.0"]
+  args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
   ingress:
     enabled: true
     host: find.data.gov.uk


### PR DESCRIPTION
It seems like sometimes the server.pid doesn't get deleted when the server is rebooted so set the pid location to a tmp directory which should be cleared after a pod is restarted. 

Also update the README for improved testing practice when making changes to these charts and tidy up the code to remove unnecessary secrets. 

## Reference

https://trello.com/c/2qXYzZYb/1239-switchover-paas-apps-to-k8s-cluster