### PR TITLE
Add static harvest source to CKAN chart

### DIFF
--- a/charts/ckan/images/test/static-harvest-source.yaml
+++ b/charts/ckan/images/test/static-harvest-source.yaml
@@ -1,0 +1,2 @@
+repository: ghcr.io/alphagov/static-ckan-harvest-source
+tag: 1.0.0

--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -1,0 +1,27 @@
+{{- if $.Values.dev.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-static-harvest-source
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-static-harvest-source
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-static-harvest-source
+    spec:
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+        - name: static-harvest-source
+          image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "static-harvest-source" "files" $.Files) }}'
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 11088
+{{- end }}

--- a/charts/ckan/templates/static-harvest-source/service.yaml
+++ b/charts/ckan/templates/static-harvest-source/service.yaml
@@ -1,0 +1,14 @@
+{{- if $.Values.dev.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-static-harvest-source
+spec:
+  selector:
+    app: {{ .Release.Name }}-static-harvest-source
+  ports:
+    - name: http
+      protocol: TCP
+      port: 11088
+      targetPort: http
+{{- end }}


### PR DESCRIPTION
Adds a static harvest source service on a local development machine to generate the test data.