### PR TITLE
Change log level from DEBUG to INFO + minor cleanup.

### DIFF
--- a/charts/ckan/templates/ckan/configmap.yaml
+++ b/charts/ckan/templates/ckan/configmap.yaml
@@ -224,12 +224,6 @@ data:
     args = (sys.stderr,)
     level = NOTSET
     formatter = generic
-    
-    [handler_file]
-    class = logging.handlers.RotatingFileHandler
-    formatter = generic
-    level = NOTSET
-    args = ("/var/log/ckan/ckan.log", "a", 20000000, 9)
-    
+
     [formatter_generic]
     format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/charts/ckan/templates/ckan/configmap.yaml
+++ b/charts/ckan/templates/ckan/configmap.yaml
@@ -217,7 +217,7 @@ data:
     propagate = 0
     
     [logger_ckanext]
-    level = DEBUG
+    level = INFO
     handlers = console
     ; handlers = console
     qualname = ckanext

--- a/charts/ckan/templates/ckan/configmap.yaml
+++ b/charts/ckan/templates/ckan/configmap.yaml
@@ -16,43 +16,43 @@ data:
     #
     # The %(here)s variable will be replaced with the parent directory of this file
     #
-    
+
     [DEFAULT]
-    
+
     # WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
     debug = false
-    
+
     [server:main]
     use = egg:Paste#http
     host = 0.0.0.0
     port = 5000
-    
+
     [app:main]
     use = egg:ckan
     full_stack = true
     cache_dir = /tmp/ckan/
     beaker.session.key = ckan
-    
+
     beaker.session.secret = placeholder
     app_instance_uuid = fdee5057-84ad-4b96-804a-d8c2dc027721
-    
+
     who.config_file = /etc/ckan/who.ini
     who.log_level = warning
     who.log_file = %(cache_dir)s/who_log.ini
         
     #ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
     #ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
-    
+
     # PostgreSQL' full-text search parameters
     ckan.datastore.default_fts_lang = english
     ckan.datastore.default_fts_index_method = gist
-    
+
     ## Site Settings
-    
+
     ckan.use_pylons_response_cleanup_middleware = true
-    
+
     ## Authorization Settings
-    
+
     ckan.auth.anon_create_dataset = false
     ckan.auth.create_unowned_dataset = false
     ckan.auth.create_dataset_if_not_in_organization = false
@@ -63,35 +63,35 @@ data:
     ckan.auth.create_user_via_api = true
     ckan.auth.create_user_via_web = true
     ckan.auth.roles_that_cascade_to_sub_groups = admin
-    
+
     ## User Account Creation Setting
     ckan.valid_email_regexes = .gov.uk$ .nhs.uk$ .nhs.net$ .ac.uk$ .os.uk$ .mod.uk$ .police.uk$ .bl.uk$
-    
+
     ## CORS Settings
-    
+
     # If cors.origin_allow_all is true, all origins are allowed.
     # If false, the cors.origin_whitelist is used.
     ckan.cors.origin_allow_all = true
     # cors.origin_whitelist is a space separated list of allowed domains.
     # ckan.cors.origin_whitelist = http://example1.com http://example2.com
-    
-    
+
+
     ## Plugins Settings
-    
+
     # Note: Add ``datastore`` to enable the CKAN DataStore
     #       Add ``datapusher`` to enable DataPusher
     #       Add ``resource_proxy`` to enable resorce proxying and get around the
     #       same origin policy
-    
+
     ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester inventory_harvester
-    
+
     # These are marked as legacy harvesters
     # gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester
-    
+
     # This needs fixing
     # inventory_harvester
-    
-    
+
+
     # Harvesting settings
     ckan.harvest.mq.type = redis
     ckan.harvest.mq.hostname = {{ .Values.ckan.config.redis.host | default (print .Release.Name "-redis") }}
@@ -100,16 +100,16 @@ data:
 
     # 12 hours timeout
     ckan.harvest.timeout = 720
-    
+
     ckan.redis.url = redis://{{ .Values.ckan.config.redis.host | default (print .Release.Name "-redis") }}:{{ .Values.ckan.config.redis.port | default "6379" }}/{{ .Values.ckan.config.redis.dbNumber | default "1" }}
 
     ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
     ckan.spatial.validator.reject = true
-    
+
     # Define which views should be created by default
     # (plugins must be loaded in ckan.plugins)
     # ckan.views.default_views = image_view text_view recline_view
-    
+
     ## Front-End Settings
     ckan.site_title = {{ .Values.ckan.config.site.title }}
     ckan.site_description = {{ .Values.ckan.config.site.description }}
@@ -118,7 +118,7 @@ data:
     ckan.preview.direct = png jpg gif
     ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
     ckan.display_timezone = server
-    
+
     # package_hide_extras = for_search_index_only
     #package_edit_return_url = http://another.frontend/dataset/<NAME>
     #package_new_return_url = http://another.frontend/dataset/<NAME>
@@ -128,101 +128,97 @@ data:
     #licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
     # ckan.template_footer_end =
     ckan.group_and_organization_list_max = 2000
-    
-    
+
+
     ## Internationalisation Settings
     ckan.locale_default = en_GB
     ckan.locale_order = en_GB
     ckan.locales_offered = en_GB
     ckan.locales_filtered_out = en_US
     ckan.i18n_directory = /usr/lib/ckan/venv/src/ckanext-datagovuk/ckanext/datagovuk/
-    
+
     ## Feeds Settings
-    
+
     ckan.feeds.authority_name =
     ckan.feeds.date =
     ckan.feeds.author_name =
     ckan.feeds.author_link =
-    
+
     ## Storage Settings
-    
+
     ckan.storage_path = /var/lib/ckan
     ckan.max_resource_size = 50
     #ckan.max_image_size = 2
-    
+
     ## S3 Settngs
     ckan.datagovuk.s3_aws_access_key_id =
     ckan.datagovuk.s3_aws_secret_access_key =
     ckan.datagovuk.s3_bucket_name = {{ .Values.ckan.config.s3.bucketName }}
     ckan.datagovuk.s3_url_prefix = {{ .Values.ckan.config.s3.urlPrefix }}
     ckan.datagovuk.s3_aws_region_name = {{ .Values.ckan.config.s3.regionName }}
-    
+
     ## CKAN 2.9 settings
     ckan.route_after_login = dashboard.datasets
     ckan.mock_harvest_source = {{ .Values.ckan.config.mock_harvest_source }}
-    
+
     ## Legacy route mappings
     #ckan.legacy_route_mappings = {"home":"home.index", "about": "home.about"}
-    
+
     ## GA Settings
     #googleanalytics.account = data.gov.uk
     #googleanalytics.id = UA-10855508-1
     #googleanalytics.token.filepath = /vagrant/src/ga_token
     #ga-report.bounce_url = /
     #ga-report.period = monthly
-    
+
     ## Datapusher settings
-    
+
     # Make sure you have set up the DataStore
-    
+
     #ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
     #ckan.datapusher.url = http://127.0.0.1:8800/
-    
+
     # Resource Proxy settings
     # Preview size limit, default: 1MB
     #ckan.resource_proxy.max_file_size = 1048576
     # Size of chunks to read/write.
     #ckan.resource_proxy.chunk_size = 4096
-    
+
     ## Activity Streams Settings
-    
+
     #ckan.activity_streams_enabled = true
     #ckan.activity_list_limit = 31
     #ckan.activity_streams_email_notifications = true
     #ckan.email_notifications_since = 2 days
     #ckan.hide_activity_from_users = %(ckan.site_id)s
-    
-    
+
+
     ## Logging configuration
     [loggers]
     keys = root, ckan, ckanext
-    
+
     [handlers]
     keys = console
-    ; keys = console
-    
+
     [formatters]
     keys = generic
-    
+
     [logger_root]
     level = INFO
     handlers = console
-    ; handlers = console
-    
+
     [logger_ckan]
     level = INFO
     handlers = console
-    ; handlers = console
     qualname = ckan
     propagate = 0
-    
+
     [logger_ckanext]
     level = INFO
     handlers = console
-    ; handlers = console
     qualname = ckanext
     propagate = 0
-    
+
     [handler_console]
     class = StreamHandler
     args = (sys.stderr,)

--- a/charts/ckan/templates/pycsw/configmap.yaml
+++ b/charts/ckan/templates/pycsw/configmap.yaml
@@ -42,7 +42,7 @@ data:
     encoding=UTF-8
     language=en-US
     maxrecords=10
-    loglevel=DEBUG
+    loglevel=INFO
     logfile=/dev/stdout
     #ogc_schemas_base=http://foo
     #federatedcatalogues=http://catalog.data.gov/csw


### PR DESCRIPTION
As a rule of thumb, we don't normally want to be running with debug logging in production.

Our log storage is fairly expensive so this helps keeps costs down. We can always enable it ad-hoc as and when we need it.

Also a bit of trivial cleanup in those config files while we're there. Separate commits for clarity.