### PR TITLE
Keep just 2 previous replicasets instead of 10.

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-ckan
 spec:
   replicas: {{ .Values.ckan.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-ckan

--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-postgres
 spec:
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-postgres

--- a/charts/ckan/templates/pycsw/deployment.yaml
+++ b/charts/ckan/templates/pycsw/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-pycsw
 spec:
   replicas: {{ .Values.pycsw.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-pycsw

--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Release.Name }}-static-harvest-source
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-static-harvest-source

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-find
 spec:
   replicas: {{ .Values.find.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-find

--- a/charts/datagovuk/templates/opensearch/deployment.yaml
+++ b/charts/datagovuk/templates/opensearch/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-opensearch
 spec:
   replicas: {{ .Values.opensearch.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-opensearch

--- a/charts/datagovuk/templates/publish/deployment.yaml
+++ b/charts/datagovuk/templates/publish/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Release.Name }}-publish
 spec:
   replicas: {{ .Values.publish.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: {{ .Release.Name }}-publish


### PR DESCRIPTION
There's no operational reason for us to keep more than a couple of previous revisions of replicasets around (if that).

Set [revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) the same as we do for the rest of GOV.UK. Helps to reduce clutter in the Argo CD web UI and slightly reduces load on etcd.