### PR TITLE
Enable AWS Shield Advanced and LB request logs on all data.gov.uk LBs.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -11,6 +11,10 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
         alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-integration-aws-logging,
+          access_logs.s3.prefix=elb/ckan-datagovuk
       tls:
         enabled: true
     probes:
@@ -86,10 +90,14 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
         alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-integration-aws-logging,
+          access_logs.s3.prefix=elb/www-datagovuk
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
-            [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "www.integration.data.gov.uk"
-            ]}}]
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "www.integration.data.gov.uk"
+          ]}}]
   opensearch:
     replicaCount: 1
   externalSecret:

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -9,6 +9,7 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
       tls:
         enabled: true
@@ -83,6 +84,7 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -11,8 +11,12 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
         alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
-        alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:eu-west-1:172025368201:certificate/b315cd63-5ca1-4c7b-8d3b-914eccc024f8"
-        alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-dgu-lb-logs-temp,access_logs.s3.prefix=ckan
+        alb.ingress.kubernetes.io/certificate-arn: >
+          arn:aws:acm:eu-west-1:172025368201:certificate/b315cd63-5ca1-4c7b-8d3b-914eccc024f8
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-production-aws-logging,
+          access_logs.s3.prefix=elb/ckan-datagovuk
       tls:
         enabled: true
     probes:
@@ -83,10 +87,14 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
         alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-production-aws-logging,
+          access_logs.s3.prefix=elb/www-datagovuk
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
-            [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "www.data.gov.uk"
-            ]}}]
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "www.data.gov.uk"
+          ]}}]
   opensearch:
     replicaCount: 1
   externalSecret:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -9,6 +9,7 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:eu-west-1:172025368201:certificate/b315cd63-5ca1-4c7b-8d3b-914eccc024f8"
         alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=govuk-dgu-lb-logs-temp,access_logs.s3.prefix=ckan
@@ -80,6 +81,7 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
             [{"field": "host-header", "hostHeaderConfig": { "values": [

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -9,6 +9,7 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
       tls:
         enabled: true

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -11,6 +11,10 @@ ckanHelmValues:
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
         alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-staging-aws-logging,
+          access_logs.s3.prefix=elb/ckan-datagovuk
       tls:
         enabled: true
     probes:
@@ -83,11 +87,16 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/shield-advanced-protection: "true"
         alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/load-balancer-attributes: >
+          access_logs.s3.enabled=true,
+          access_logs.s3.bucket=govuk-staging-aws-logging,
+          access_logs.s3.prefix=elb/www-datagovuk
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
-            [{"field": "host-header", "hostHeaderConfig": { "values": [
-                "www.staging.data.gov.uk"
-            ]}}]
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "www.staging.data.gov.uk"
+          ]}}]
   opensearch:
     replicaCount: 1
   externalSecret:


### PR DESCRIPTION
Enable AWS Shield Advanced everywhere, since we already pay for it. Same deal as https://github.com/alphagov/govuk-helm-charts/pull/1246.

Also enable LB request logging everywhere and use our usual S3 buckets for that.