### PR TITLE
Fix missing hostnames on non-prod ingresses.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -82,7 +82,7 @@ datagovukHelmValues:
     replicaCount: 1
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     ingress:
-      host: integration.data.gov.uk
+      host: find.eks.integration.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
@@ -96,7 +96,8 @@ datagovukHelmValues:
           access_logs.s3.prefix=elb/www-datagovuk
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
-              "www.integration.data.gov.uk"
+              "www.integration.data.gov.uk",
+              "integration.data.gov.uk"
           ]}}]
   opensearch:
     replicaCount: 1

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -81,7 +81,7 @@ datagovukHelmValues:
     replicaCount: 1
     args: [ "bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid" ]
     ingress:
-      host: staging.data.gov.uk
+      host: find.eks.staging.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
@@ -95,7 +95,8 @@ datagovukHelmValues:
           access_logs.s3.prefix=elb/www-datagovuk
         alb.ingress.kubernetes.io/conditions.datagovuk-find: >
           [{"field": "host-header", "hostHeaderConfig": { "values": [
-              "www.staging.data.gov.uk"
+              "www.staging.data.gov.uk",
+              "staging.data.gov.uk"
           ]}}]
   opensearch:
     replicaCount: 1


### PR DESCRIPTION
Fastly is configured to forward requests to `find.eks.{integration,staging}.govuk.digital`, but those weren't actually configured on the load balancers.