### PR TITLE
Add ckan nginx to set safelist

### DIFF
--- a/charts/ckan/templates/ckan/configmap.yaml
+++ b/charts/ckan/templates/ckan/configmap.yaml
@@ -25,7 +25,7 @@ data:
     [server:main]
     use = egg:Paste#http
     host = 0.0.0.0
-    port = 5000
+    port = {{ .Values.ckan.appPort }}
 
     [app:main]
     use = egg:ckan

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $fullName := print .Release.Name "-ckan" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,7 +57,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - name: http
-              containerPort: 5000
+              containerPort: {{ .Values.ckan.appPort }}
           volumeMounts:
             - name: config
               mountPath: /config
@@ -88,6 +89,44 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 60
           {{- end }}
+        - name: nginx
+          image: "{{ .Values.ckan.nginx.image.repository }}:{{ .Values.ckan.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.ckan.nginx.image.pullPolicy | default "Always" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ckan.nginx.port }}
+          livenessProbe: &nginx-probe
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            <<: *nginx-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+            timeoutSeconds: 15
+          {{- with .Values.ckan.nginx.resources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-tmp
+              mountPath: /tmp
+            {{- with .Values.ckan.nginx.extraVolumeMounts }}
+              {{ . | toYaml | trim | nindent 12 }}
+            {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
       volumes:
         - name: ckan-init
           configMap:
@@ -96,4 +135,9 @@ spec:
           configMap:
             name: {{ .Release.Name }}-ckan-production-ini
         - name: config
+          emptyDir: {}
+        - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+          configMap:
+            name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+        - name: nginx-tmp
           emptyDir: {}

--- a/charts/ckan/templates/ckan/ingress.yaml
+++ b/charts/ckan/templates/ckan/ingress.yaml
@@ -20,7 +20,7 @@ spec:
               service:
                 name: {{ $.Release.Name }}-ckan
                 port:
-                  number: 5000
+                  number: {{ $.Values.ckan.service.port }}
           - path: /csw
             pathType: Prefix
             backend:

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.ckan.nginx.configMap.create }}
+{{- $fullName := (print .Release.Name "-ckan") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-nginx-conf
+  labels:
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: nginx
+data:
+  nginx.conf: |-
+
+    error_log  /dev/stderr warn;
+    pid        /tmp/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      proxy_buffer_size 16k;  # Max total size of response headers.
+      # n * m = max response size before spooling to disk. p95 response size should
+      # fit comfortably within this in order to avoid performance issues.
+      proxy_buffers 24 16k;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      # Set GOVUK-Request-Id if not set
+      map $http_govuk_request_id $govuk_request_id {
+        default $http_govuk_request_id;
+        ''      "$pid-$msec-$remote_addr-$request_length";
+      }
+
+      # Default values for response headers. These values are used when the
+      # header is not already set on the incoming response.
+      # https://serverfault.com/a/598106
+      map $upstream_http_strict_transport_security $strict_transport_security {
+        "" "max-age=31536000; preload";
+      }
+      map $upstream_http_permissions_policy $permissions_policy {
+        "" "interest-cohort=()";
+      }
+      map $upstream_http_x_content_type_options $x_content_type_options {
+        "" "nosniff";
+      }
+
+      log_format json_event escape=json '{'
+        '"@timestamp":"$time_iso8601",'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"bytes_sent":$bytes_sent,'
+        '"govuk_request_id":"$govuk_request_id",'
+        '"http_host":"$http_host",'
+        '"http_referer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request_method":"$request_method",'
+        '"request_time":$request_time,'
+        '"request_uri":"$request_uri",'
+        '"sent_http_content_type":"$sent_http_content_type",'
+        '"sent_http_location":"$sent_http_location",'
+        '"server_protocol":"$server_protocol",'
+        '"status":$status,'
+        '"upstream_addr":"$upstream_addr",'
+        '"upstream_response_time":"$upstream_response_time"'
+      '}';
+
+      upstream {{ $fullName }} {
+        server 127.0.0.1:{{ .Values.ckan.appPort }};
+      }
+
+      server {
+        listen {{ .Values.ckan.nginx.port }};
+        proxy_connect_timeout {{ .Values.ckan.nginx.proxyConnectTimeout }};
+        proxy_read_timeout    {{ .Values.ckan.nginx.proxyReadTimeout }};
+
+        access_log /dev/stdout json_event;
+        error_log /dev/stderr;
+
+        # Where the response header is already set on the incoming response,
+        # these are no-ops. https://serverfault.com/a/598106
+        add_header Strict-Transport-Security $strict_transport_security;
+        add_header Permissions-Policy $permissions_policy;
+        add_header X-Content-Type-Options $x_content_type_options always;
+
+        {{- if ( or (ne .Values.environment "production") (eq .Values.ckan.nginx.denyCrawlers true ) ) }}
+        add_header X-Robots-Tag "noindex";
+        {{- end }}
+
+        location / {
+          proxy_set_header   Host $http_host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header GOVUK-Request-Id $govuk_request_id;
+          proxy_pass         http://{{ $fullName }};
+          proxy_redirect     off;
+          client_max_body_size {{ .Values.ckan.nginx.clientMaxBodySize }};
+        }
+
+        # Endpoint for liveness and readiness checks of the nginx container.
+        location = /readyz {
+          return 200 'ok\n';
+        }
+
+        # allow access to safelist of endpoints
+        {{- range $path := .Values.ckan.nginx.safelist }}
+        location ~ ^/(api|api/3){{ $path }} {
+          proxy_set_header   Host $http_host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header GOVUK-Request-Id $govuk_request_id;
+          proxy_pass         http://{{ $fullName }}/$uri$is_args$args;
+          proxy_redirect     off;
+          client_max_body_size {{ $.Values.ckan.nginx.clientMaxBodySize }};
+        }
+        {{- end }}
+
+        # deny access to other api endpoints
+        location ~ ^/(api|api/3) {
+          deny all;
+          return 403;
+        }
+      }
+    }
+{{- end }}

--- a/charts/ckan/templates/ckan/service.yaml
+++ b/charts/ckan/templates/ckan/service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 5000
-      targetPort: http
+      port: {{ $.Values.ckan.service.port }}
+      targetPort: {{ .Values.ckan.nginx.port }}

--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -13,7 +13,7 @@ spec:
             - name: pycsw
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "pycsw" "files" $.Files) }}'
               imagePullPolicy: Always
-              command: [ "/bin/sh", "-c", "ckan ckan-pycsw load -p $CKAN_CONFIG/pycsw.cfg -u http://{{ .Release.Name }}-ckan:5000" ]
+              command: [ "/bin/sh", "-c", "ckan ckan-pycsw load -p $CKAN_CONFIG/pycsw.cfg -u http://{{ .Release.Name }}-ckan:{{ .Values.ckan.appPort }}" ]
               env:
                 - name: PYCSW_CONFIG
                   value: /config/pycsw.cfg

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -5,6 +5,7 @@ ckan:
   serviceAccount:
     enabled: false
     iamRoleARN: ""
+  appPort: 5000
   args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120 --workers 8"]
   ingress:
     enabled: true
@@ -61,11 +62,67 @@ ckan:
           name: ckan
           key: aws_secret_access_key
 
+  service:
+    annotations: {}
+    port: 80
+
+  nginx:
+    image:
+      repository: public.ecr.aws/nginx/nginx
+      pullPolicy: Always
+      tag: stable-perl
+    port: 8080
+    proxyConnectTimeout: 1s
+    proxyReadTimeout: 15s
+    clientMaxBodySize: 1M
+    configMap:
+      create: true
+      name: ""
+    extraVolumeMounts: []
+    denyCrawlers: false
+    safelist:
+      # Used by: ckan.publishing.service.gov.uk
+      # Used for: internationalisation of form controls
+      - "/i18n"
+
+      # Used by: ckan.publishing.service.gov.uk
+      # Used for: finding members
+      - "/2/util/user/autocomplete"
+
+      # Used by: datagovuk_publish
+      # Used for: ckan_v26_ckan_org_sync
+      - "/action/organization_list"
+      - "/action/organization_show"
+
+      # Used by: datagovuk_publish
+      # Used for: ckan_v26_package_sync job
+      # Used by: pycsw data load in ckanext-spatial
+      # Used for: syncing csw with ckan database
+      - "/search/dataset"
+
+      # Used by: datagovuk_publish
+      # Used for: ckan_v26_package_sync job
+      - "/action/package_show"
+
+      # Used by: datagovuk_publish
+      # Used for: determining filetype
+      - "/2/util/resource/format_autocomplete"
+
+      # Used by: datagovuk_find
+      # Used for: addtional metadata links for datasets
+      - "/2/rest/harvestobject"
+
+      # Additional endpoints requested by users
+      - "/action/package_search"
+      - "/action/package_list"
+      - "/action/harvest_source_list"
+
 solr:
   enabled: true
   persistence:
     enabled: false
     persistentVolumeClaimName: "solr"
+
 # This postgres instance is for development purposes only
 postgres:
   enabled: true

--- a/charts/datagovuk/templates/_publish.tpl
+++ b/charts/datagovuk/templates/_publish.tpl
@@ -4,7 +4,7 @@
   value: {{ .Values.find.ingress.host }}
 {{- with .Values.publish.config }}
 - name: CKAN_URL
-  value: http://{{ .ckanReleaseName }}-ckan:5000
+  value: http://{{ .ckanReleaseName }}-ckan:{{ .ckanPort }}
 - name: DATABASE_URL
   valueFrom:
     secretKeyRef:
@@ -15,9 +15,9 @@
 - name: RAILS_ENV
   value: {{ $environment }}
 - name: REDIS_HOST
-  value: {{ .redis.host | default "dgu-redis" }}
+  value: {{ .redis.host | default "dgu-shared-redis" }}
 - name: REDIS_URL
-  value: redis://{{ .redis.host | default "dgu-redis" }}/{{ .redis.dbNumber | default "1" }}
+  value: redis://{{ .redis.host | default "dgu-shared-redis" }}/{{ .redis.dbNumber | default "1" }}
 - name: ES_INDEX
   value: datasets-{{ $environment }}
 - name: RAILS_LOG_TO_STDOUT

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -12,6 +12,7 @@ publish:
   args: ["bundle exec rake db:migrate db:seed && bundle exec sidekiq"]
   config:
     ckanReleaseName: "ckan-dev"
+    ckanPort: 5000
     sqlalchemyUrlSecretKeyRef:
       name: datagovuk
       key: publish_sqlalchemy_url


### PR DESCRIPTION
Safelist a set of CKAN API endpoints to minimise risk of PII leak.

This safelist is based on the old puppet code - 

https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk/templates/ckan/nginx.conf.erb#L28-L79