### PR TITLE
Raise log threshold from INFO to WARNING.

### DIFF
--- a/charts/ckan/templates/ckan/configmap.yaml
+++ b/charts/ckan/templates/ckan/configmap.yaml
@@ -204,17 +204,17 @@ data:
     keys = generic
 
     [logger_root]
-    level = INFO
+    level = WARNING
     handlers = console
 
     [logger_ckan]
-    level = INFO
+    level = WARNING
     handlers = console
     qualname = ckan
     propagate = 0
 
     [logger_ckanext]
-    level = INFO
+    level = WARNING
     handlers = console
     qualname = ckanext
     propagate = 0

--- a/charts/ckan/templates/pycsw/configmap.yaml
+++ b/charts/ckan/templates/pycsw/configmap.yaml
@@ -42,7 +42,7 @@ data:
     encoding=UTF-8
     language=en-US
     maxrecords=10
-    loglevel=INFO
+    loglevel=WARNING
     logfile=/dev/stdout
     #ogc_schemas_base=http://foo
     #federatedcatalogues=http://catalog.data.gov/csw

--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -14,6 +14,8 @@
   value: "https://www.gov.uk"
 - name: RAILS_ENV
   value: {{ $environment }}
+- name: RAILS_LOG_LEVEL
+  value: "warn"
 - name: RAILS_LOG_TO_STDOUT
   value: "1"
 - name: RAILS_DEVELOPMENT_HOSTS


### PR DESCRIPTION
datagovuk is logging a *lot* — it accounts for 6% of our total log throughput but 0.025% of our total traffic — and our log storage/ingest quota is not cheap.

I sampled a bunch of INFO-level logs and didn't find anything that looks worth keeping. It's also easy to turn the verbosity back up if/when we need it.

https://github.com/alphagov/datagovuk_find/pull/1207 implements RAILS_LOG_LEVEL in Find.