### PR TITLE
Reduce solr logspew.

### DIFF
--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -32,6 +32,10 @@ spec:
       containers:
         - name: solr
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "solr" "files" $.Files) }}'
+          env:
+            {{- with .Values.solr.extraEnv }}
+              {{ . | toYaml | nindent 12 }}
+            {{- end }}
           ports:
             - name: solr
               containerPort: 8983

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -122,6 +122,9 @@ solr:
   persistence:
     enabled: false
     persistentVolumeClaimName: "solr"
+  extraEnv:
+    - name: SOLR_LOG_LEVEL
+      value: WARN
 
 # This postgres instance is for development purposes only
 postgres:


### PR DESCRIPTION
Solr is pretty noisy by default.

Tested: inspected output of `helm template .`.