### PR TITLE
Avoid multiple `pycsw load` cronjobs piling up.

### DIFF
--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -3,12 +3,18 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-pycsw-load
 spec:
-  schedule: "0 0 * * *"
+  schedule: "1 47 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 171000  # 171000 s = 47.5 hours.
       template:
         spec:
           {{- include "ckan.pycsw-init" . | nindent 10 }}
+          restartPolicy: Never
           containers:
             - name: pycsw
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "pycsw" "files" $.Files) }}'
@@ -21,5 +27,4 @@ spec:
               volumeMounts:
                 - name: config
                   mountPath: /config
-          restartPolicy: OnFailure
           {{ include "ckan.pycsw-volumes" . | nindent 10 }}


### PR DESCRIPTION
- Prevent concurrent runs.
- Allow up to 48h for a successful run (probably excessive, but easy to change).
- Don't retry; just wait for the next nightly run.
- Adjust the start time so as to avoid midnight and pick a random minute.
- Tune the job history limits.