### PR TITLE
Unbreak uploading large files to CKAN.

### DIFF
--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -72,9 +72,9 @@ ckan:
       pullPolicy: Always
       tag: stable
     port: 8080
-    proxyConnectTimeout: 1s
-    proxyReadTimeout: 15s
-    clientMaxBodySize: 1M
+    proxyConnectTimeout: 2s
+    proxyReadTimeout: 30s
+    clientMaxBodySize: 50M
     configMap:
       create: true
       name: ""


### PR DESCRIPTION
1 MB limit was introduced in #90.

While we're there, make the timeouts a bit more generous.