### PR TITLE
Fix transposition error in cron schedule.

### DIFF
--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-pycsw-load
 spec:
-  schedule: "1 47 * * *"
+  schedule: "47 1 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
D'oh. Got the hour/minute mixed up in 40746c9. Sorry for the noise.

Filed #99 to track fixing the lack of validation.