### PR TITLE
Enable Reloader on all Deployments in datagovuk.

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-ckan
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.ckan.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/ckan/templates/ckan/fetch-deployment.yaml
+++ b/charts/ckan/templates/ckan/fetch-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-fetch
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.fetch.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/ckan/templates/ckan/gather-deployment.yaml
+++ b/charts/ckan/templates/ckan/gather-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-gather
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.gather.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-postgres
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   revisionHistoryLimit: 2
   selector:

--- a/charts/ckan/templates/pycsw/deployment.yaml
+++ b/charts/ckan/templates/pycsw/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-pycsw
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.pycsw.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-static-harvest-source
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-find
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.find.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/datagovuk/templates/opensearch/deployment.yaml
+++ b/charts/datagovuk/templates/opensearch/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-opensearch
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.opensearch.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/datagovuk/templates/publish/deployment.yaml
+++ b/charts/datagovuk/templates/publish/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-publish
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: {{ .Values.publish.replicaCount }}
   revisionHistoryLimit: 2


### PR DESCRIPTION
Just hardcoding the annotation for now, since there isn't really any reason not to.