### PR TITLE
Avoid startup dependency on DockerHub.

### DIFF
--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -68,7 +68,7 @@ ckan:
 
   nginx:
     image:
-      repository: nginx
+      repository: public.ecr.aws/nginx/nginx
       pullPolicy: Always
       tag: stable
     port: 8080


### PR DESCRIPTION
Pull the nginx image from ECR instead of DockerHub. Avoids an unnecessary third-party dependency on pod startup.