### PR TITLE
Add opensearch sts

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -103,6 +103,7 @@ datagovukHelmValues:
     replicaCount: 1
     persistence:
       enabled: true
+      persistentVolumeClaimName: opensearch-sts
   externalSecret:
     enabled: true
 

--- a/charts/datagovuk/templates/opensearch-sts/pvc.yaml
+++ b/charts/datagovuk/templates/opensearch-sts/pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.opensearch.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.opensearch.persistence.persistentVolumeClaimName }}
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+{{- end }}

--- a/charts/datagovuk/templates/opensearch-sts/service.yaml
+++ b/charts/datagovuk/templates/opensearch-sts/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-opensearch-sts
+spec:
+  selector:
+    app: {{ .Release.Name }}-opensearch-sts
+  ports:
+    - name: host-port
+      protocol: TCP
+      port: 9200
+      targetPort: host-port
+    - name: node-port
+      protocol: TCP
+      port: 9600
+      targetPort: node-port

--- a/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
+++ b/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-opensearch-sts
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.opensearch.replicaCount }}
+  revisionHistoryLimit: 2
+  serviceName: "opensearch"
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-opensearch-sts
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-opensearch-sts
+    spec:
+      {{- if .Values.opensearch.persistence.enabled }}
+      initContainers:
+        - name: fix-volume-permissions
+          image: {{ .Values.opensearch.image }}
+          command: [ bash, -c, "chown -R opensearch:opensearch /usr/share/opensearch/data"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+      {{- end }}
+      containers:
+        - name: opensearch
+          image: {{ .Values.opensearch.image }}
+          ports:
+            - name: host-port
+              containerPort: 9200
+            - name: node-port
+              containerPort: 9600
+          env:
+            - name: bootstrap.memory_lock
+              value: "true" # along with the memlock settings below, disables swapping
+            - name: OPENSEARCH_JAVA_OPTS
+              value: -Xms512m -Xmx512m # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+            - name: DISABLE_INSTALL_DEMO_CONFIG
+              value: "true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
+            - name: DISABLE_SECURITY_PLUGIN
+              value: "true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
+            - name: discovery.type
+              value: single-node
+          {{- if .Values.opensearch.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+          {{- end }}
+      {{- if .Values.opensearch.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.opensearch.persistence.persistentVolumeClaimName }}
+      {{- end }}

--- a/charts/datagovuk/templates/opensearch/deployment.yaml
+++ b/charts/datagovuk/templates/opensearch/deployment.yaml
@@ -43,5 +43,5 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ .Values.opensearch.persistence.persistentVolumeClaimName }}
+            claimName: opensearch
       {{- end }}


### PR DESCRIPTION
Add an opensearch statefulset to minimise downtime on data.gov.uk.

Once the `opensearch-sts` pod is ready to be populated the reindex will be triggered manually.