### PR TITLE
Give CKAN LB a persistent DNS name in production.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -15,6 +15,10 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-integration-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.ckan-datagovuk: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.integration.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -3,7 +3,7 @@ ckanHelmValues:
   ckan:
     replicaCount: 2
     ingress:
-      host: ckan.publishing.service.gov.uk
+      host: ckan.eks.production.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
@@ -17,6 +17,10 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-production-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.ckan-datagovuk: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -15,6 +15,10 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-staging-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.ckan-datagovuk: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.staging.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:


### PR DESCRIPTION
The non-prod environments already had a stable name configured for the load balancer via external-dns.

- Give prod CKAN a stable DNS name, by specifying the external-dns-managed name as the main hostname on the ingress and configuring the LB to accept the public-facing `ckan.publishing.service.gov.uk` name via annotations (like we're doing already in non-prod).
- Configure the non-prod LBs to accept their corresponding `publishing.service.gov.uk` names so that they work similarly to prod.

This lets us point `ckan.publishing.service.gov.uk` at the stable name for the load balancer rather than at the brittle, ephemeral LB name such as `k8s-datagovu-ckan-889d48a0c2-1738829154.eu-west-1.elb.amazonaws.com.`, which can change if the CKAN ingress object is deleted for any reason.