### PR TITLE
Fix CKAN ingress hostname conditions in non-prod.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -15,6 +15,10 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-integration-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-ckan: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.integration.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -15,6 +15,10 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-staging-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-ckan: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.staging.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/ckan/templates/ckan/ingress.yaml
+++ b/charts/ckan/templates/ckan/ingress.yaml
@@ -4,12 +4,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ckan
-  {{- if not (empty .annotations) }}
   annotations:
-    {{- toYaml .annotations | trim | nindent 4 }}
-  {{- end }}
+    {{- tpl (toYaml .annotations) $ | trim | nindent 4 }}
 spec:
-  {{ if not (empty .ingressClassName) }}ingressClassName: {{ .ingressClassName }}{{ end }}
+  {{- with .ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
   rules:
     - host: {{ .host }}
       http:


### PR DESCRIPTION
This helps us verify new config to make external-dns create a stable DNS name for the LB in prod.

Tested: inspected `helm template` output,
[conditions-name](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/guide/ingress/annotations/#conditions) matches the ingress host spec this time.

```sh
helm template ../app-of-apps -f ../app-of-apps/values-integration.yaml |
  yq 'select(.metadata.name=="ckan").spec.source.helm.values' |
  helm template ckan . -f - |
  yq 'select(.kind=="Ingress")'
```