### PR TITLE
ALB needs host-header condition per service/TG.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -19,6 +19,10 @@ ckanHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "ckan.integration.publishing.service.gov.uk"
           ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-pycsw: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.integration.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -19,6 +19,10 @@ ckanHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "ckan.staging.publishing.service.gov.uk"
           ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-pycsw: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.staging.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:


### PR DESCRIPTION
Otherwise we misroute `ckan.staging.publishing.service.gov.uk/csw` requests to CKAN instead of pycsw.

e.g. this gives a csw30 XML document as expected:

```sh
curl -v https://ckan.publishing.service.gov.uk/csw
```

whereas this gives a CKAN 404 page (broken in #152):

```sh
curl -vH host:\ ckan.staging.publishing.service.gov.uk \
  https://ckan.eks.staging.govuk.digital/csw
```

whereas this gives the expected XML doc:

```
curl -v https://ckan.eks.staging.govuk.digital/csw
```