### PR TITLE
Give CKAN LB a stable DNS name in prod.

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -3,7 +3,7 @@ ckanHelmValues:
   ckan:
     replicaCount: 2
     ingress:
-      host: ckan.publishing.service.gov.uk
+      host: ckan.eks.production.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
@@ -17,6 +17,14 @@ ckanHelmValues:
           access_logs.s3.enabled=true,
           access_logs.s3.bucket=govuk-production-aws-logging,
           access_logs.s3.prefix=elb/ckan-datagovuk
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-ckan: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.publishing.service.gov.uk"
+          ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-pycsw: >
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:


### PR DESCRIPTION
Same as #152 and #153, for production.

See also https://github.com/alphagov/govuk-dns-tf/pull/195.