### PR TITLE
Revert "Avoid redundantly specifying the ingress class."

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -4,6 +4,7 @@ ckanHelmValues:
     args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
     ingress:
       host: ckan.eks.integration.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
@@ -90,6 +91,7 @@ datagovukHelmValues:
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     ingress:
       host: find.eks.integration.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -4,6 +4,7 @@ ckanHelmValues:
     replicaCount: 2
     ingress:
       host: ckan.eks.production.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
@@ -89,6 +90,7 @@ datagovukHelmValues:
       gaTrackingId: UA-10855508-1
     ingress:
       host: find.eks.production.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -4,6 +4,7 @@ ckanHelmValues:
     replicaCount: 1
     ingress:
       host: ckan.eks.staging.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
@@ -89,6 +90,7 @@ datagovukHelmValues:
     args: [ "bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid" ]
     ingress:
       host: find.eks.staging.govuk.digital
+      ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -9,9 +9,7 @@ metadata:
     {{- toYaml .annotations | trim | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .ingressClassName }}
-  ingressClassName: {{ . }}
-  {{- end }}
+  {{ if not (empty .ingressClassName) }}ingressClassName: {{ .ingressClassName }}{{ end }}
   rules:
     - host: {{ .host }}
       http:


### PR DESCRIPTION
Sorry.

Reverts alphagov/govuk-dgu-charts#175