### PR TITLE
Set the ckan cronjobs to start at 6am instead of 8am

### DIFF
--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-harvester-run
 spec:
-  schedule: "0 8-22 * * *"
+  schedule: "0 6-22 * * *"
   jobTemplate:
     spec:
       template:

--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-solr-index-rebuild
 spec:
-  schedule: "0 8-22 * * *"
+  schedule: "0 6-22 * * *"
   suspend: false
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
Some updates were being delivered beyond 10am when consumers expected them to be available at 9am, so start the jobs earlier