### PR TITLE
Set Google Tag Manager properties for Find

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -89,6 +89,9 @@ datagovukHelmValues:
   find:
     replicaCount: 1
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
+    config:
+      googleTagManagerAuth: 5FunvYw9Lsi6YtwO0jllcQ
+      googleTagManagerPreview: env-38
     ingress:
       host: find.eks.integration.govuk.digital
       ingressClassName: aws-alb

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -88,6 +88,7 @@ datagovukHelmValues:
     args: [ "bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid" ]
     config:
       gaTrackingId: UA-10855508-1
+      googleTagManagerId: GTM-M875Q8TH
     ingress:
       host: find.eks.production.govuk.digital
       ingressClassName: aws-alb

--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -27,6 +27,18 @@
 - name: GA_TRACKING_ID
   value: {{ . }}
 {{- end }}
+{{- with .googleTagManagerId }}
+- name: GOOGLE_TAG_MANAGER_ID
+  value: {{ . }}
+{{- end }}
+{{- with .googleTagManagerAuth }}
+- name: GOOGLE_TAG_MANAGER_AUTH
+  value: {{ . }}
+{{- end }}
+{{- with .googleTagManagerPreview }}
+- name: GOOGLE_TAG_MANAGER_PREVIEW
+  value: {{ . }}
+{{- end }}
 - name: SECRET_KEY_BASE
   valueFrom:
     secretKeyRef:

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -36,6 +36,9 @@ find:
   config:
     ckanDomain: "ckan.publishing.service.gov.uk"
     gaTrackingId: ""
+    googleTagManagerId: ""
+    googleTagManagerAuth: ""
+    googleTagManagerPreview: ""
     secretKeyBaseSecretKeyRef:
       name: datagovuk
       key: secret_key_base


### PR DESCRIPTION
UA is being decomissioned, so this is being migrated to GA4. UA references are still being retained.