### PR TITLE
Adding Google Tag Manager ID to integration.

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -90,6 +90,7 @@ datagovukHelmValues:
     replicaCount: 1
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     config:
+      googleTagManagerId: GTM-M875Q8TH
       googleTagManagerAuth: 5FunvYw9Lsi6YtwO0jllcQ
       googleTagManagerPreview: env-38
     ingress:


### PR DESCRIPTION
Part of GA4 implementation to DGU Find.

Trello card: https://trello.com/c/VdzhWk09/3456-migrate-datagovuk-page-views-tracking-from-ua-to-ga4-3