### PR TITLE
Revert "Update image tags for production (v1.4.0)"

### DIFF
--- a/charts/ckan/images/production/ckan.yaml
+++ b/charts/ckan/images/production/ckan.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/ckan
-tag: v1.4.0
+tag: v1.3.1
 branch: main

--- a/charts/ckan/images/production/pycsw.yaml
+++ b/charts/ckan/images/production/pycsw.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/pycsw
-tag: v1.4.0
+tag: v1.3.1
 branch: main

--- a/charts/ckan/images/production/solr.yaml
+++ b/charts/ckan/images/production/solr.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/solr
-tag: v1.4.0
+tag: v1.3.1
 branch: main


### PR DESCRIPTION
This correlates with Gemini 2.3 validation errors on this harvest job: https://govuk.zendesk.com/agent/tickets/5813155

Let's see if rolling back helps.

Reverts alphagov/govuk-dgu-charts#186