### PR TITLE
Update ckan 2.10.4

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -27,6 +27,7 @@ ckanHelmValues:
         enabled: true
     probes:
       enabled: false
+    ckanIniConfigMap: ckan-production-ini
     config:
       dbInit: false
       site:

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -27,7 +27,7 @@ ckanHelmValues:
         enabled: true
     probes:
       enabled: false
-    ckanIniConfigMap: ckan-production-ini
+    ckanIniConfigMap: ckan-production-ini-2-10
     config:
       dbInit: false
       site:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -29,6 +29,7 @@ ckanHelmValues:
         enabled: true
     probes:
       enabled: true
+    ckanIniConfigMap: ckan-production-ini
     config:
       dbInit: false
       site:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -27,6 +27,7 @@ ckanHelmValues:
         enabled: true
     probes:
       enabled: true
+    ckanIniConfigMap: ckan-production-ini
     config:
       dbInit: false
       site:

--- a/charts/ckan/images/integration/ckan.yaml
+++ b/charts/ckan/images/integration/ckan.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/ckan
-tag: 7b2361134be3b86e0d6202f3aaaac26a50f03ad1
+tag: da48eb5b549c703c0f16f1943849340754c3f68f
 branch: main

--- a/charts/ckan/images/integration/pycsw.yaml
+++ b/charts/ckan/images/integration/pycsw.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/pycsw
-tag: 7b2361134be3b86e0d6202f3aaaac26a50f03ad1
+tag: 2.6.1-e
 branch: main

--- a/charts/ckan/images/integration/solr.yaml
+++ b/charts/ckan/images/integration/solr.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/solr
-tag: 7b2361134be3b86e0d6202f3aaaac26a50f03ad1
+tag: "2.10"
 branch: main

--- a/charts/ckan/images/test/ckan.yaml
+++ b/charts/ckan/images/test/ckan.yaml
@@ -1,2 +1,3 @@
 repository: ghcr.io/alphagov/ckan
-tag: v1.3.0
+tag: da48eb5b549c703c0f16f1943849340754c3f68f
+branch: main

--- a/charts/ckan/images/test/pycsw.yaml
+++ b/charts/ckan/images/test/pycsw.yaml
@@ -1,2 +1,3 @@
 repository: ghcr.io/alphagov/pycsw
-tag: v1.3.0
+tag: 2.6.1-e
+branch: main

--- a/charts/ckan/images/test/solr.yaml
+++ b/charts/ckan/images/test/solr.yaml
@@ -1,2 +1,3 @@
 repository: ghcr.io/alphagov/solr
-tag: v1.3.0
+tag: "2.10"
+branch: main

--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -31,7 +31,7 @@
 - name: CKAN_CONFIG
   value: /config/
 - name: CKAN_INI
-  value: {{ .ckanIni }}
+  value: /config/production.ini
 - name: CKAN_REDIS_URL
   value: redis://{{ .redis.host | default (print $.Release.Name "-redis") }}/{{ .redis.dbNumber | default "1" }}
   {{- if $.Values.dev.enabled }}

--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -5,6 +5,16 @@
     secretKeyRef:
       name: {{ .sqlalchemyUrlSecretKeyRef.name }}
       key: {{ .sqlalchemyUrlSecretKeyRef.key }}
+- name: CKAN_BEAKER_SESSION_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .beakerSessionSecretKeyRef.name }}
+      key: {{ .beakerSessionSecretKeyRef.key }}
+- name: CKAN_BEAKER_SESSION_VALIDATE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .beakerSessionValidateKeyRef.name }}
+      key: {{ .beakerSessionValidateKeyRef.key }}
 - name: CKAN_DB_INIT
   value: "{{ .dbInit | default "false" }}"
 - name: CKAN_DB_HOST

--- a/charts/ckan/templates/_pycsw.tpl
+++ b/charts/ckan/templates/_pycsw.tpl
@@ -6,11 +6,6 @@ initContainers:
     imagePullPolicy: Always
     env:
       {{- include "ckan.environment-variables" . | nindent 6 }}
-      - name: CKAN_BEAKER_SESSION_SECRET
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
-            key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
     volumeMounts:
       - name: pycsw-cfg
         mountPath: /pycsw

--- a/charts/ckan/templates/_pycsw.tpl
+++ b/charts/ckan/templates/_pycsw.tpl
@@ -34,7 +34,7 @@ volumes:
       name: {{ .Release.Name }}-pycsw-init
   - name: production-ini
     configMap:
-      name: {{ .Release.Name }}-ckan-production-ini
+      name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
   - name: config
     emptyDir: {}
 {{- end }}

--- a/charts/ckan/templates/ckan/configmap-2.10.yaml
+++ b/charts/ckan/templates/ckan/configmap-2.10.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-ckan-production-ini-2-10
 data:
-  production-2.10.ini: |
+  production.ini: |
     #
     # CKAN configuration
     #

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -49,9 +49,6 @@ spec:
             - name: production-ini
               mountPath: /map
               readOnly: true
-            - name: production-ini-2-10
-              mountPath: /map-2.10
-              readOnly: true
             - name: config
               mountPath: /config
             - name: ckan-init
@@ -138,10 +135,7 @@ spec:
             name: {{ .Release.Name }}-ckan-init
         - name: production-ini
           configMap:
-            name: {{ .Release.Name }}-ckan-production-ini
-        - name: production-ini-2-10
-          configMap:
-            name: {{ .Release.Name }}-ckan-production-ini-2-10
+            name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
         - name: config
           emptyDir: {}
         - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -28,11 +28,6 @@ spec:
           imagePullPolicy: Always
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
-            - name: CKAN_BEAKER_SESSION_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
-                  key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
             {{- if .Values.dev.enabled }}
             - name: CKAN_AWS_ACCESS_KEY_ID
               valueFrom:

--- a/charts/ckan/templates/ckan/fetch-deployment.yaml
+++ b/charts/ckan/templates/ckan/fetch-deployment.yaml
@@ -30,4 +30,4 @@ spec:
       volumes:
         - name: production-ini
           configMap:
-            name: {{ .Release.Name }}-ckan-production-ini
+            name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}

--- a/charts/ckan/templates/ckan/gather-deployment.yaml
+++ b/charts/ckan/templates/ckan/gather-deployment.yaml
@@ -30,4 +30,4 @@ spec:
       volumes:
         - name: production-ini
           configMap:
-            name: {{ .Release.Name }}-ckan-production-ini
+            name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}

--- a/charts/ckan/templates/ckan/init-configmap.yaml
+++ b/charts/ckan/templates/ckan/init-configmap.yaml
@@ -9,6 +9,7 @@ data:
 
     # update production.ini
     ckan config-tool $CKAN_INI "beaker.session.secret=$CKAN_BEAKER_SESSION_SECRET"
+    ckan config-tool $CKAN_INI "beaker.session.validate_key=$CKAN_BEAKER_SESSION_VALIDATE_KEY"
 
     {{- if $.Values.dev.enabled }}
     ckan config-tool $CKAN_INI "ckan.mock_harvest_source = http://{{ $.Release.Name }}-static-harvest-source:11088/"

--- a/charts/ckan/templates/ckan/init-configmap.yaml
+++ b/charts/ckan/templates/ckan/init-configmap.yaml
@@ -7,9 +7,6 @@ data:
     # copy production.ini
     cp /map/production.ini /config
 
-    # copy production-2.10.ini
-    cp /map-2.10/production-2.10.ini /config
-
     # update production.ini
     ckan config-tool $CKAN_INI "beaker.session.secret=$CKAN_BEAKER_SESSION_SECRET"
 

--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -23,4 +23,4 @@ spec:
           volumes:
             - name: production-ini
               configMap:
-                name: {{ .Release.Name }}-ckan-production-ini
+                name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}

--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -25,4 +25,4 @@ spec:
           volumes:
             - name: production-ini
               configMap:
-                name: {{ .Release.Name }}-ckan-production-ini
+                name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -36,6 +36,9 @@ ckan:
     beakerSessionSecretKeyRef:
       name: ckan
       key: beaker_session_secret
+    beakerSessionValidateKeyRef:
+      name: ckan
+      key: beaker_session_validate_key
     solr:
       url: ""
       user: ""

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -16,8 +16,8 @@ ckan:
       enabled: false
   probes:
     enabled: false
+  ckanIniConfigMap: ckan-production-ini-2-10
   config:
-    ckanIni: /config/production.ini
     dbInit: true
     site:
       id: "dgu"

--- a/local-dev.yaml
+++ b/local-dev.yaml
@@ -5,10 +5,10 @@ metadata:
 type: Opaque
 stringData:
   sqlalchemy_url: "postgresql://ckan:ckan@ckan-dev-postgres/ckan"
-  publish_sqlalchemy_url: "postgresql://ckan:ckan@ckan-dev-postgres/publish"
   solr_password: "ckan"
   smtp_password: "ckan"
   beaker_session_secret: "9EZiPwkeS+cZpqb0VDWrN+Q0M"
+  beaker_session_validate_key: "UIZYT0m866FiFutxNP2cac2892i"
   aws_access_key_id: "test"
   aws_secret_access_key: "test"
 ---


### PR DESCRIPTION
Change the way that the config file is generated as allowing different versions of production.ini to be created was difficult to manage. 

Also set the beaker session validation key from secrets.

NOTE - to pick up the updated config file on Staging and Production the `ckanIniConfigMap` value needs to be removed or updated.