### PR TITLE
Set RAILS_ENV in publish

### DIFF
--- a/charts/datagovuk/templates/_publish.tpl
+++ b/charts/datagovuk/templates/_publish.tpl
@@ -3,6 +3,8 @@
 - name: FIND_URL
   value: {{ .Values.find.ingress.host }}
 {{- with .Values.publish.config }}
+- name: RAILS_ENV
+  value: {{ $environment }}
 - name: CKAN_URL
   value: http://{{ .ckanReleaseName }}-ckan
 - name: DATABASE_URL


### PR DESCRIPTION
As the RAILS_ENV defaults to production if it isn't set, Integration and Staging publish were actually going to the production endpoint rather than the correct CKAN endpoint for their environment which meant that changes in CKAN were not being properly published.

Setting the correct RAILS_ENV fixes this.