### PR TITLE
Fix ckan domain find

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -94,6 +94,7 @@ datagovukHelmValues:
       googleTagManagerId: GTM-M875Q8TH
       googleTagManagerAuth: 5FunvYw9Lsi6YtwO0jllcQ
       googleTagManagerPreview: env-38
+      ckanDomain: "ckan.integration.publishing.service.gov.uk"
     ingress:
       host: find.eks.integration.govuk.digital
       ingressClassName: aws-alb

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -107,6 +107,8 @@ datagovukHelmValues:
               "www.staging.data.gov.uk",
               "staging.data.gov.uk"
           ]}}]
+    config:
+      ckanDomain: "ckan.staging.publishing.service.gov.uk"
   opensearch:
     replicaCount: 1
     persistence:


### PR DESCRIPTION
Would default to ckan.publishing.service.gov.uk without these settings.