### PR TITLE
Add Arch Switches to Helm Charts for ARM/Graviton

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/ckan
-    targetRevision: HEAD
+    targetRevision: dj-maisy/dgu-arm-integration
     helm:
       values: |
         {{- toYaml .Values.ckanHelmValues | nindent 8 }}

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/dgu-shared
-    targetRevision: HEAD
+    targetRevision: dj-maisy/dgu-arm-integration
     helm:
       values: |
         {{- toYaml .Values.dguSharedHelmValues | nindent 8 }}

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-ckan
+        app.kubernetes.io/arch: {{ .Values.ckan.arch }}
     spec:
       securityContext:
         runAsUser: 900
@@ -138,3 +139,12 @@ spec:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
         - name: nginx-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.ckan.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.ckan.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.ckan.arch }}
+      {{- end }}

--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -24,3 +24,12 @@ spec:
             - name: production-ini
               configMap:
                 name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+          {{- if eq "arm64" .Values.ckan.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.ckan.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.ckan.arch }}
+          {{- end }}

--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -28,3 +28,12 @@ spec:
                 - name: config
                   mountPath: /config
           {{ include "ckan.pycsw-volumes" . | nindent 10 }}
+          {{- if eq "arm64" .Values.pycsw.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.pycsw.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.pycsw.arch }}
+          {{- end }}

--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-postgres
+        app.kubernetes.io/arch: {{ .Values.postgres.arch }}
     spec:
       containers:
         - name: postgres
@@ -36,5 +37,14 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.postgres.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.postgres.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.postgres.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.postgres.arch }}
       {{- end }}
 {{- end }}

--- a/charts/ckan/templates/pycsw/deployment.yaml
+++ b/charts/ckan/templates/pycsw/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-pycsw
+        app.kubernetes.io/arch: {{ .Values.pycsw.arch }}
     spec:
       securityContext:
         runAsUser: 900
@@ -45,3 +46,12 @@ spec:
             periodSeconds: 3
           {{- end }}
       {{ include "ckan.pycsw-volumes" . | nindent 6 }}
+      {{- if eq "arm64" .Values.pycsw.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.pycsw.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.pycsw.arch }}
+      {{- end }}

--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-solr
+        app.kubernetes.io/arch: {{ .Values.solr.arch }}
     spec:
       securityContext:
         runAsUser: 8983
@@ -72,5 +73,14 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.solr.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.solr.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.solr.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.solr.arch }}
       {{- end }}
 {{- end }}

--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -27,4 +27,13 @@ spec:
           ports:
             - name: http
               containerPort: 11088
+      {{- if eq "arm64" .Values.ckan.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.ckan.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.ckan.arch }}
+      {{- end }}
 {{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -6,6 +6,7 @@ ckan:
     enabled: false
     iamRoleARN: ""
   appPort: 5000
+  arch: arm64
   args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120 --workers 8"]
   ingress:
     enabled: true
@@ -123,6 +124,7 @@ ckan:
 
 solr:
   enabled: true
+  arch: arm64
   persistence:
     enabled: false
     persistentVolumeClaimName: "solr"
@@ -133,6 +135,7 @@ solr:
 # This postgres instance is for development purposes only
 postgres:
   enabled: true
+  arch: arm64
   image: ghcr.io/alphagov/postgis:13-3.1
   persistence:
     enabled: false
@@ -149,6 +152,7 @@ fetch:
 
 pycsw:
   replicaCount: 1
+  arch: arm64
   args: ["python $CKAN_VENV/src/pycsw/pycsw/wsgi.py"]
   probes:
     enabled: false

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-find
+        app.kubernetes.io/arch: {{ .Values.find.arch }}
     spec:
       containers:
         - name: find
@@ -38,3 +39,12 @@ spec:
       volumes:
         - name: app-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.find.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.find.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.find.arch }}
+      {{- end }}

--- a/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
+++ b/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-opensearch-sts
+        app.kubernetes.io/arch: {{ .Values.opensearch.arch }}
     spec:
       {{- if .Values.opensearch.persistence.enabled }}
       initContainers:
@@ -57,4 +58,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.opensearch.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.opensearch.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.opensearch.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.opensearch.arch }}
       {{- end }}

--- a/charts/datagovuk/templates/publish/deployment.yaml
+++ b/charts/datagovuk/templates/publish/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-publish
+        app.kubernetes.io/arch: {{ .Values.publish.arch }}
     spec:
       initContainers:
         - name: config-set
@@ -42,3 +43,12 @@ spec:
             name: {{ .Release.Name }}-publish-init
         - name: app-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.publish.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.publish.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.publish.arch }}
+      {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -2,6 +2,7 @@ environment: test
 
 opensearch:
   replicaCount: 1
+  arch: arm64
   image: opensearchproject/opensearch
   persistence:
     enabled: false
@@ -9,6 +10,7 @@ opensearch:
 
 publish:
   replicaCount: 1
+  arch: arm64
   config:
     ckanReleaseName: "ckan-dev"
     dbSetup: "no"
@@ -28,6 +30,7 @@ publish:
 
 find:
   replicaCount: 1
+  arch: arm64
   args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
   ingress:
     enabled: true

--- a/charts/dgu-shared/templates/redis/statefulset.yaml
+++ b/charts/dgu-shared/templates/redis/statefulset.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-redis
+        app.kubernetes.io/arch: {{ .Values.redis.arch }}
     spec:
       {{- if .Values.redis.persistence.enabled }}
       initContainers:
@@ -40,4 +41,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.redis.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.redis.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.redis.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.redis.arch }}
       {{- end }}

--- a/charts/dgu-shared/values.yaml
+++ b/charts/dgu-shared/values.yaml
@@ -3,6 +3,7 @@ environment: test
 redis:
   replicaCount: 1
   enabled: true
+  arch: arm64
   image: redis:6.2.5-alpine3.14
   persistence:
     enabled: true


### PR DESCRIPTION
## What?
This adds tolerations for most of the DGU Helm Chart Deployments so they can be configured to work on ARM or Graviton-based EKS Nodes. With this configuration, the architecture can be switched for each app/container/microservice by changing the value setting as appropriate.