### PR TITLE
Switch targetRevision to the ARM branch.

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/ckan
-    targetRevision: HEAD
+    targetRevision: dj-maisy/dgu-arm-integration
     helm:
       values: |
         {{- toYaml .Values.ckanHelmValues | nindent 8 }}

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/dgu-shared
-    targetRevision: HEAD
+    targetRevision: dj-maisy/dgu-arm-integration
     helm:
       values: |
         {{- toYaml .Values.dguSharedHelmValues | nindent 8 }}


### PR DESCRIPTION
## What?
This picks the `targetRevision` changes from the [ARM branch](https://github.com/alphagov/govuk-dgu-charts/pull/321) into main so we can keep the ARM changes forked until ready to be merged to main.

Do we need to change this as well?
https://github.com/alphagov/govuk-dgu-charts/blob/e1218f6d19bf2f63b12c6a30dd8beeb801bfeae9/charts/app-of-apps/templates/datagovuk-application.yaml#L11
