### PR TITLE
Move argo-bootstrap into the datagovuk namespace

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/ckan
-    targetRevision: HEAD
+    targetRevision: move-argo-bootstrap-to-datagovuk-namespace
     helm:
       values: |
         {{- toYaml .Values.ckanHelmValues | nindent 8 }}

--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/datagovuk
-    targetRevision: HEAD
+    targetRevision: move-argo-bootstrap-to-datagovuk-namespace
     helm:
       values: |
         {{- toYaml .Values.datagovukHelmValues | nindent 8 }}

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/alphagov/govuk-dgu-charts
     path: charts/dgu-shared
-    targetRevision: HEAD
+    targetRevision: move-argo-bootstrap-to-datagovuk-namespace
     helm:
       values: |
         {{- toYaml .Values.dguSharedHelmValues | nindent 8 }}

--- a/charts/argo-bootstrap/templates/application.yaml
+++ b/charts/argo-bootstrap/templates/application.yaml
@@ -13,13 +13,13 @@ spec:
         - values-{{ .Values.environment }}.yaml
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: datagovuk
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false
+      - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
       - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
Description:
- Currently `argo-bootstrap` is in the default namespace. It should really belong in the `datagovuk` namespace with the other datagovuk applications