### PR TITLE
[WIP] - Set DGU PSS to baseline

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -14,13 +14,19 @@ spec:
         {{- toYaml .Values.ckanHelmValues | nindent 8 }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: datagovuk
+    namespace: {{ .Values.appNamespace }}
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: {{ .Values.argoNamespace }}
+        pod-security.kubernetes.io/audit: "restricted"
+        pod-security.kubernetes.io/enforce: "baseline"
+        pod-security.kubernetes.io/warn: "restricted"

--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -14,13 +14,19 @@ spec:
         {{- toYaml .Values.datagovukHelmValues | nindent 8 }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: datagovuk
+    namespace: {{ .Values.appNamespace }}
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: {{ .Values.argoNamespace }}
+        pod-security.kubernetes.io/audit: "restricted"
+        pod-security.kubernetes.io/enforce: "baseline"
+        pod-security.kubernetes.io/warn: "restricted"

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -14,13 +14,19 @@ spec:
         {{- toYaml .Values.dguSharedHelmValues | nindent 8 }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: datagovuk
+    namespace: {{ .Values.appNamespace }}
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        argocd.argoproj.io/managed-by: {{ .Values.argoNamespace }}
+        pod-security.kubernetes.io/audit: "restricted"
+        pod-security.kubernetes.io/enforce: "baseline"
+        pod-security.kubernetes.io/warn: "restricted"

--- a/charts/app-of-apps/values.yaml
+++ b/charts/app-of-apps/values.yaml
@@ -1,3 +1,6 @@
+argoNamespace: cluster-services
+appNamespace: datagovuk
+
 ckanHelmValues:
   ckan:
     replicaCount: 1


### PR DESCRIPTION
Description:
- Set `CreateNamespace=true` to allow use of `managedNamespaceMetadata` (see [here](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/#namespace-metadata))
- `datagovuk` namespace is already created in the cluster
- Enforce `baseline` but audit and warn on `restricted`
- See prior art [here](https://github.com/alphagov/govuk-helm-charts/pull/2713)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883