### PR TITLE
Sync only if `datagovuk` namespace exists

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -20,7 +20,7 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true

--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -20,7 +20,7 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -20,7 +20,7 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=false
+    - CreateNamespace=true
     - PrunePropagationPolicy=foreground
     - PruneLast=true
     - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
Description:
- Setting `CreateNamespace=true` means that the Argo application will only sync if the namespace exists. If it doesn't exist it will create it