### PR TITLE
Helm Updates to support ARCH Tolerations for DGU

### DIFF
--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -1,5 +1,6 @@
 ckanHelmValues:
   environment: staging
+  arch: arm64
   ckan:
     replicaCount: 1
     ingress:
@@ -73,6 +74,7 @@ ckanHelmValues:
 
 datagovukHelmValues:
   environment: staging
+  arch: arm64
   publish:
     replicaCount: 1
     args: [ "bundle exec rake db:migrate db:seed && bundle exec sidekiq" ]
@@ -118,5 +120,6 @@ datagovukHelmValues:
     enabled: true
 
 dguSharedHelmValues:
+  arch: arm64
   redis:
     replicaCount: 1

--- a/charts/ckan/images/test/ckan.yaml
+++ b/charts/ckan/images/test/ckan.yaml
@@ -1,3 +1,3 @@
-repository: ghcr.io/alphagov/ckan
-tag: da48eb5b549c703c0f16f1943849340754c3f68f
+repository: local-registry:52452/ckan
+tag: 2.10.4
 branch: main

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-ckan
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
         runAsUser: 900
@@ -138,3 +139,12 @@ spec:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
         - name: nginx-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/ckan/templates/ckan/fetch-deployment.yaml
+++ b/charts/ckan/templates/ckan/fetch-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-fetch
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       containers:
         - name: harvest-fetch
@@ -31,3 +32,12 @@ spec:
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/ckan/templates/ckan/gather-deployment.yaml
+++ b/charts/ckan/templates/ckan/gather-deployment.yaml
@@ -31,3 +31,12 @@ spec:
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -2,11 +2,21 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-harvester-run
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
   schedule: "0 6-22 * * *"
   jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-harvester-run
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       template:
+        metadata:
+          name: {{ .Release.Name }}-harvester-run
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
         spec:
           containers:
             - name: ckan
@@ -24,3 +34,12 @@ spec:
             - name: production-ini
               configMap:
                 name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}

--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -2,16 +2,26 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-pycsw-load
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
   schedule: "47 1 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 2
   jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-pycsw-load
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       backoffLimit: 0
       activeDeadlineSeconds: 171000  # 171000 s = 47.5 hours.
       template:
+        metadata:
+          name: {{ .Release.Name }}-pycsw-load
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
         spec:
           {{- include "ckan.pycsw-init" . | nindent 10 }}
           restartPolicy: Never
@@ -28,3 +38,12 @@ spec:
                 - name: config
                   mountPath: /config
           {{ include "ckan.pycsw-volumes" . | nindent 10 }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}

--- a/charts/ckan/templates/cronjobs/reindex-organisations.yaml
+++ b/charts/ckan/templates/cronjobs/reindex-organisations.yaml
@@ -2,11 +2,21 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-reindex-organisations
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
   schedule: "0 8 * * *"
   jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-reindex-organisations
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       template:
+        metadata:
+          name: {{ .Release.Name }}-reindex-organisations
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
         spec:
           containers:
             - name: ckan
@@ -24,3 +34,12 @@ spec:
             - name: production-ini
               configMap:
                 name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}

--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -2,13 +2,23 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-solr-index-rebuild
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
   schedule: "0 6-22 * * *"
   suspend: false
   concurrencyPolicy: Forbid
   jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-solr-index-rebuild
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       template:
+        metadata:
+          name: {{ .Release.Name }}-solr-index-rebuild
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
         spec:
           containers:
             - name: ckan
@@ -26,3 +36,12 @@ spec:
             - name: production-ini
               configMap:
                 name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}

--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-postgres
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       containers:
         - name: postgres
@@ -36,5 +37,14 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.postgres.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}
 {{- end }}

--- a/charts/ckan/templates/pycsw/deployment.yaml
+++ b/charts/ckan/templates/pycsw/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-pycsw
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
         runAsUser: 900
@@ -45,3 +46,12 @@ spec:
             periodSeconds: 3
           {{- end }}
       {{ include "ckan.pycsw-volumes" . | nindent 6 }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-solr
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
         runAsUser: 8983
@@ -72,5 +73,14 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.solr.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}
 {{- end }}

--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-static-harvest-source
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
         runAsUser: 0
@@ -27,4 +28,13 @@ spec:
           ports:
             - name: http
               containerPort: 11088
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
 {{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -1,5 +1,10 @@
 environment: test
 
+# arch determines whether the app should schedule on amd64 or arm64 nodes.
+# TODO: remove `arch` once the ARM migration is complete and we're no longer
+# running mixed-arch clusters.
+arch: amd64
+
 ckan:
   replicaCount: 1
   serviceAccount:

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-find
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       containers:
         - name: find
@@ -38,3 +39,12 @@ spec:
       volumes:
         - name: app-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
+++ b/charts/datagovuk/templates/opensearch-sts/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-opensearch-sts
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       {{- if .Values.opensearch.persistence.enabled }}
       initContainers:
@@ -57,4 +58,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.opensearch.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}

--- a/charts/datagovuk/templates/publish/deployment.yaml
+++ b/charts/datagovuk/templates/publish/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-publish
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       initContainers:
         - name: config-set
@@ -42,3 +43,12 @@ spec:
             name: {{ .Release.Name }}-publish-init
         - name: app-tmp
           emptyDir: {}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -1,5 +1,10 @@
 environment: test
 
+# arch determines whether the app should schedule on amd64 or arm64 nodes.
+# TODO: remove `arch` once the ARM migration is complete and we're no longer
+# running mixed-arch clusters.
+arch: amd64
+
 opensearch:
   replicaCount: 1
   image: opensearchproject/opensearch

--- a/charts/dgu-shared/templates/redis/statefulset.yaml
+++ b/charts/dgu-shared/templates/redis/statefulset.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-redis
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       {{- if .Values.redis.persistence.enabled }}
       initContainers:
@@ -40,4 +41,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.redis.persistence.persistentVolumeClaimName }}
+      {{- end }}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}

--- a/charts/dgu-shared/values.yaml
+++ b/charts/dgu-shared/values.yaml
@@ -1,5 +1,10 @@
 environment: test
 
+# arch determines whether the app should schedule on amd64 or arm64 nodes.
+# TODO: remove `arch` once the ARM migration is complete and we're no longer
+# running mixed-arch clusters.
+arch: amd64
+
 redis:
   replicaCount: 1
   enabled: true


### PR DESCRIPTION
## What?
Ooof, this is a big one. So this adds tolerations and "Node Selection" sections to each of the CronJob, Deployment and StatefulSet templates so we can configure the Architecture setting per environment for DGU.