### PR TITLE
Remove arch from Staging values as overrides the default amd64

### DIFF
--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -74,7 +74,6 @@ ckanHelmValues:
 
 datagovukHelmValues:
   environment: staging
-  arch: arm64
   publish:
     replicaCount: 1
     args: [ "bundle exec rake db:migrate db:seed && bundle exec sidekiq" ]


### PR DESCRIPTION
The arch value of arm64 is causing problems running the web apps in datagovuk so remove it to use the default amd64