### PR TITLE
Bump Pycsw tag to version that has ARM support

### DIFF
--- a/charts/ckan/images/staging/pycsw.yaml
+++ b/charts/ckan/images/staging/pycsw.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/pycsw
-tag: 2.6.1-j
+tag: 2.6.1-n
 branch: main

--- a/charts/ckan/templates/ckan/gather-deployment.yaml
+++ b/charts/ckan/templates/ckan/gather-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-gather
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       containers:
         - name: harvest-gather


### PR DESCRIPTION
## What?
This bumps the pycsw image tag used in staging to 2.6.1-n (which has an ARM version built) to resolve the Init CrashLoop.