### PR TITLE
Switch Solr image tag to 2.10-c in Staging

### DIFF
--- a/charts/ckan/images/staging/solr.yaml
+++ b/charts/ckan/images/staging/solr.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/solr
-tag: 2.10-a
+tag: 2.10-c
 branch: main


### PR DESCRIPTION
## What?
This switches the image used for Solr from 2.10-a to 2.10-c, as this has an ARM version available. Hopefully this will address the `Init:CrashLookBackOff` issue we're experiencing.