### PR TITLE
Add GOVUK_ENVIRONMENT_NAME environment variable

### DIFF
--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -8,6 +8,8 @@
   value: datasets-{{ $environment }}
 - name: GOVUK_APP_DOMAIN
   value: "www.gov.uk"
+- name: GOVUK_ENVIRONMENT_NAME
+  value: {{ $environment }}
 - name: GOVUK_PROMETHEUS_EXPORTER
   value: "force"
 - name: GOVUK_WEBSITE_ROOT


### PR DESCRIPTION
We want to use it to tag Sentry errors to appropriate environment.

Note that other GOV.UK apps that use govuk_app_config gem use SENTRY_CURRENT_ENV for this purpose. But since we don't use the gem for DGU, more generic GOVUK_ENVIRONMENT_NAME is used here.