### PR TITLE
Add external secret staging and remove publish image shas

### DIFF
--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -97,6 +97,8 @@ datagovukHelmValues:
           ]}}]
     config:
       ckanDomain: "ckan.staging.publishing.service.gov.uk"
+  externalSecret:
+    enabled: true
 
 dguSharedHelmValues:
   arch: arm64

--- a/charts/datagovuk/images/integration/publish.yaml
+++ b/charts/datagovuk/images/integration/publish.yaml
@@ -1,3 +1,0 @@
-repository: ghcr.io/alphagov/datagovuk_publish
-tag: 7c4802b2c43a6290b7559ee299ed7330ac3a210f
-branch: main

--- a/charts/datagovuk/images/production/publish.yaml
+++ b/charts/datagovuk/images/production/publish.yaml
@@ -1,3 +1,0 @@
-repository: ghcr.io/alphagov/datagovuk_publish
-tag: v2.21.0
-branch: main

--- a/charts/datagovuk/images/staging/publish.yaml
+++ b/charts/datagovuk/images/staging/publish.yaml
@@ -1,3 +1,0 @@
-repository: ghcr.io/alphagov/datagovuk_publish
-tag: v2.21.0
-branch: main

--- a/charts/datagovuk/images/test/publish.yaml
+++ b/charts/datagovuk/images/test/publish.yaml
@@ -1,2 +1,0 @@
-repository: ghcr.io/alphagov/datagovuk_publish
-tag: b31f03c62843e59157f813537659622d18e2b2c2


### PR DESCRIPTION
externalSecret setting was accidentally removed, this will prevent the Find pod from running as it can't find the secret