### PR TITLE
Correct PSS restricted compliance for `datagovuk`

### DIFF
--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -54,7 +54,6 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
-      {{- if eq "arm64" .Values.arch }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
@@ -62,6 +61,7 @@ spec:
         fsGroup: 1001
         seccompProfile:
           type: RuntimeDefault
+      {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch
           operator: Equal


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-dgu-charts/pull/446 incorrectly set the `securityContext` to only apply if the architecture is arm64
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883