### PR TITLE
Enforce postgres deployment to be PSS restricted compliant

### DIFF
--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -27,6 +27,10 @@ spec:
               value: ckan
             - name: POSTGRES_PASSWORD
               value: ckan
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           {{- if .Values.postgres.persistence.enabled }}
           volumeMounts:
             - name: data
@@ -38,6 +42,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.postgres.persistence.persistentVolumeClaimName }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
Description:
- Used only for local development but good practice to have it hardened
- Enforce the deployment to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883