### PR TITLE
Enforce `static-harvest-source` to be PSS restricted compliant

### DIFF
--- a/charts/ckan/templates/static-harvest-source/deployment.yaml
+++ b/charts/ckan/templates/static-harvest-source/deployment.yaml
@@ -18,9 +18,12 @@ spec:
         app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: static-harvest-source
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "static-harvest-source" "files" $.Files) }}'
@@ -28,6 +31,10 @@ spec:
           ports:
             - name: http
               containerPort: 11088
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
Description:
- Used only for local development but good practice to have it hardened
- Enforce the deployment to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883