### PR TITLE
Enforce postgres PSS compliant restricted

### DIFF
--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -27,6 +27,10 @@ spec:
               value: ckan
             - name: POSTGRES_PASSWORD
               value: ckan
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           {{- if .Values.postgres.persistence.enabled }}
           volumeMounts:
             - name: data
@@ -38,6 +42,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.postgres.persistence.persistentVolumeClaimName }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
Description:
- Postgres user is 70 in Alpine (see https://github.com/docker-library/postgres/blob/master/13/alpine3.21/Dockerfile#L9)
- Used only for local development but good practice to have it hardened
- Enforce the deployment to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883