### PR TITLE
Revert "Revert "Enforce postgres PSS compliant restricted""

### DIFF
--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -27,6 +27,10 @@ spec:
               value: ckan
             - name: POSTGRES_PASSWORD
               value: ckan
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           {{- if .Values.postgres.persistence.enabled }}
           volumeMounts:
             - name: data
@@ -38,6 +42,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.postgres.persistence.persistentVolumeClaimName }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch


### PR DESCRIPTION
Reverts alphagov/govuk-dgu-charts#463

We're confident that the issue was due to no ARM build. This has been patched in https://github.com/alphagov/govuk-dgu-charts/pull/464