### PR TITLE
Update pycsw init containers to PSS restricted

### DIFF
--- a/charts/ckan/templates/_pycsw.tpl
+++ b/charts/ckan/templates/_pycsw.tpl
@@ -17,6 +17,10 @@ initContainers:
         mountPath: /config
       - name: pycsw-init
         mountPath: /init
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ "ALL" ]
 {{- end }}
 
 {{- define "ckan.pycsw-volumes" -}}


### PR DESCRIPTION
Description:
- Enforce the deployment to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883