### PR TITLE
Enforce `pycsw` cronjob to be compliant when PSS is set to restricted

### DIFF
--- a/charts/ckan/templates/_pycsw.tpl
+++ b/charts/ckan/templates/_pycsw.tpl
@@ -20,7 +20,7 @@ initContainers:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
+        drop: ["ALL"]
 {{- end }}
 
 {{- define "ckan.pycsw-volumes" -}}

--- a/charts/ckan/templates/cronjobs/pycsw-load.yaml
+++ b/charts/ckan/templates/cronjobs/pycsw-load.yaml
@@ -37,7 +37,18 @@ spec:
               volumeMounts:
                 - name: config
                   mountPath: /config
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
           {{ include "ckan.pycsw-volumes" . | nindent 10 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
           {{- if eq "arm64" .Values.arch }}
           tolerations:
             - key: arch


### PR DESCRIPTION
Description:
- Enforce the deployment to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883