### PR TITLE
Enforce solr main container to be compliant with PSS restricted

### DIFF
--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -20,17 +20,22 @@ spec:
         app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 8983
         runAsGroup: 8983
         fsGroup: 8983
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.solr.persistence.enabled }}
       initContainers:
         - name: fix-volume-permissions
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "solr" "files" $.Files) }}'
           command: [ bash, -c, "chown -R solr:solr /var/solr/data"]
           securityContext:
+            runAsNonRoot: false
             runAsUser: 0
             runAsGroup: 0
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: data
               mountPath: /var/solr/data
@@ -50,6 +55,10 @@ spec:
             - name: data
               mountPath: /var/solr/data
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           startupProbe:
             httpGet:
               path: /solr/ckan/admin/ping


### PR DESCRIPTION
Description:
- Enforces `solr` main container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883