### PR TITLE
Enforce `ckan` to be compliant with PSS restricted

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -23,10 +23,15 @@ spec:
         app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
     spec:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 900
         runAsGroup: 900
         fsGroup: 900
-      {{ if .Values.ckan.serviceAccount.enabled }}serviceAccountName: {{ .Values.ckan.serviceAccount.name | default (print "ckan-" .Release.Name) }}{{- end }}
+        seccompProfile:
+          type: RuntimeDefault
+      {{ if .Values.ckan.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.ckan.serviceAccount.name | default (print "ckan-" .Release.Name) }}
+      {{- end }}
       initContainers:
         - name: config-set
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
@@ -46,6 +51,10 @@ spec:
                   name: {{ .Values.ckan.config.s3.credentials.awsSecretAccessKeySecretKeyRef.name }}
                   key: {{ .Values.ckan.config.s3.credentials.awsSecretAccessKeySecretKeyRef.key }}
             {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: production-ini
               mountPath: /map
@@ -69,6 +78,10 @@ spec:
           args: {{ .Values.ckan.args }}
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           {{- if .Values.ckan.probes.enabled }}
           livenessProbe:
             httpGet:
@@ -117,6 +130,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf

--- a/charts/ckan/templates/ckan/fetch-deployment.yaml
+++ b/charts/ckan/templates/ckan/fetch-deployment.yaml
@@ -28,10 +28,21 @@ spec:
           args: ["ckan harvester fetch-consumer"]
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 900
+        runAsGroup: 900
+        fsGroup: 900
+        seccompProfile:
+          type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch

--- a/charts/ckan/templates/ckan/gather-deployment.yaml
+++ b/charts/ckan/templates/ckan/gather-deployment.yaml
@@ -28,10 +28,21 @@ spec:
           args: ["ckan harvester gather-consumer"]
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 900
+        runAsGroup: 900
+        fsGroup: 900
+        seccompProfile:
+          type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}
       tolerations:
         - key: arch

--- a/charts/datagovuk/images/test/find.yaml
+++ b/charts/datagovuk/images/test/find.yaml
@@ -1,2 +1,3 @@
 repository: ghcr.io/alphagov/datagovuk_find
-tag: 54082f98f014fbd4cd98f1509c1220e8c7dda42d
+tag: v3.1.1
+branch: main


### PR DESCRIPTION
Description:
- Enforces this container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883