### PR TITLE
Enforce cronjobs to be compliant with PSS restricted

### DIFF
--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -29,7 +29,18 @@ spec:
                 - name: production-ini
                   mountPath: /config
                   readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: production-ini
               configMap:

--- a/charts/ckan/templates/cronjobs/reindex-organisations.yaml
+++ b/charts/ckan/templates/cronjobs/reindex-organisations.yaml
@@ -29,7 +29,18 @@ spec:
                 - name: production-ini
                   mountPath: /config
                   readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: production-ini
               configMap:

--- a/charts/ckan/templates/cronjobs/solr-index-clear.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-clear.yaml
@@ -32,7 +32,18 @@ spec:
                 - name: production-ini
                   mountPath: /config
                   readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: production-ini
               configMap:

--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -31,7 +31,18 @@ spec:
                 - name: production-ini
                   mountPath: /config
                   readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ "ALL" ]
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: production-ini
               configMap:


### PR DESCRIPTION
Description:
- Enforces this container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883