### PR TITLE
Enforce `solr` stateful set to be compliant when PSS is set to restricted

### DIFF
--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -26,20 +26,6 @@ spec:
         fsGroup: 8983
         seccompProfile:
           type: RuntimeDefault
-      {{- if .Values.solr.persistence.enabled }}
-      initContainers:
-        - name: fix-volume-permissions
-          image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "solr" "files" $.Files) }}'
-          command: [ bash, -c, "chown -R solr:solr /var/solr/data"]
-          securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
-            runAsGroup: 0
-            allowPrivilegeEscalation: false
-          volumeMounts:
-            - name: data
-              mountPath: /var/solr/data
-      {{- end }}
       containers:
         - name: solr
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "solr" "files" $.Files) }}'


### PR DESCRIPTION
Description:
- `fsGroup` ensures that the files and sub-directories are owned by the `redis` group so fixing volume permissions is unnecessary
- Permissions on the `data` directory are `drwxrwsrwx 5 root solr 4096 Feb 11 17:05 data` so the `solr` user can already read/write/execute on files/directories in `/data` so no real need to have `/data` owned by `solr`
- Enforces this container to be compliant when PSS is set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883