### PR TITLE
Set correct UID/GID on postgres container for PSS compliance

### DIFF
--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -44,9 +44,9 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 70
-        runAsGroup: 70
-        fsGroup: 70
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}


### PR DESCRIPTION
Description:
- [Postgres docker image](https://github.com/docker-library/postgres/blob/master/17/bookworm/Dockerfile#L10) has `uid=999` and `gid=999`
- Previously container wasn't starting because `70` wasn't in `/etc/passwd` as `initdb` requires that `/var/lib/postgresql/data` to be owned by `70`
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883