### PR TITLE
BAU - Disable JVM large heap page size

### DIFF
--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -130,6 +130,8 @@ solr:
   extraEnv:
     - name: SOLR_LOG_LEVEL
       value: WARN
+    - name: SOLR_OPTS
+      value: -XX:-UseLargePages
 
 # This postgres instance is for development purposes only
 postgres:


### PR DESCRIPTION
Description:
- If `GC_TUNE` isn't set then [by default](https://github.com/apache/solr/blob/main/solr/bin/solr#L1208) the JVM will have `-XX:+UseLargePages` option enabled
- Passing it in to `SOLR_OPTS` should disable it
- This is to fix `OpenJDK 64-Bit Server VM warning: Failed to reserve shared memory. (error = 1)` that Solr is throwing. The `(error = 1)` code indicates that 
```
1. shmmax is too small for Java heap.
//    > check shmmax value: cat /proc/sys/kernel/shmmax
//    > increase shmmax value: echo "0xffffffff" > /proc/sys/kernel/shmmax
```
- Disabling `UseLargePages` will use smaller page sizes so should avoid this error