### PR TITLE
Allocate more memory to Solr

### DIFF
--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 3
           resources:
             requests:
-              memory: 1024M
+              memory: 1500Mi
       {{- if .Values.solr.persistence.enabled }}
       volumes:
         - name: data


### PR DESCRIPTION
Increase the minimum resources Kubernetes will allocate to the container. The actual memory usage was on average 1.16 GiB (approximately 1186 MiB) in the past 2 weeks. It may have caused Solr to restart and cause outages.

1.16 GiB + 20% is approximately 1424 MiB 
Suggestions on the value welcome. We could go for more standard 1536Mi (1.5 GiB)

<img width="1102" alt="Screenshot 2025-03-24 at 16 35 14" src="https://github.com/user-attachments/assets/845001a5-600b-4bf2-a06b-6c32c958655a" />



