### PR TITLE
Add cascading delete finaliser to all Application resources

### DIFF
--- a/charts/app-of-apps/templates/ckan-application.yaml
+++ b/charts/app-of-apps/templates/ckan-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: ckan
   namespace: cluster-services
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: datagovuk
   source:

--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: datagovuk
   namespace: cluster-services
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: datagovuk
   source:

--- a/charts/app-of-apps/templates/dgu-shared-application.yaml
+++ b/charts/app-of-apps/templates/dgu-shared-application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: dgu-shared
   namespace: cluster-services
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: datagovuk
   source:

--- a/charts/argo-bootstrap/Chart.yaml
+++ b/charts/argo-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: argo-bootstrap
 description: Bootstraps CKAN in Argo CD
 type: application
-version: 1.2.0
+version: 1.3.0

--- a/charts/argo-bootstrap/templates/application.yaml
+++ b/charts/argo-bootstrap/templates/application.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: dgu-app-of-apps
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:


### PR DESCRIPTION
This adds a finaliser to all ArgoCD Application resources that causes ArgoCD to cascade delete child resources of these applications. This will allow us to easily remove all resources from the cluster when shutting down an ephemeral cluster.

https://github.com/alphagov/govuk-infrastructure/issues/1972