### PR TITLE
BAU - Fix local dev environment

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -101,6 +101,8 @@ datagovukHelmValues:
               "www.integration.data.gov.uk",
               "integration.data.gov.uk"
           ]}}]
+  dev:
+    enabled: false
   externalSecret:
     enabled: true
 

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -103,6 +103,8 @@ datagovukHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "www.data.gov.uk"
           ]}}]
+  dev:
+    enabled: false
   externalSecret:
     enabled: true
 

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -99,6 +99,8 @@ datagovukHelmValues:
               "www.staging.data.gov.uk",
               "staging.data.gov.uk"
           ]}}]
+  dev:
+    enabled: false
   externalSecret:
     enabled: true
 

--- a/charts/ckan/templates/postgres/deployment.yaml
+++ b/charts/ckan/templates/postgres/deployment.yaml
@@ -44,9 +44,9 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
         seccompProfile:
           type: RuntimeDefault
       {{- if eq "arm64" .Values.arch }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -1,7 +1,7 @@
 environment: test
 
 dev:
-  enabled: false
+  enabled: true
 
 # arch determines whether the app should schedule on amd64 or arm64 nodes.
 # TODO: remove `arch` once the ARM migration is complete and we're no longer


### PR DESCRIPTION
Description:
- Set `.dev.enabled.true` as default and override the configuration in the `values-<environment>` file. This is because if not enabled `datagovuk-find` will expect to retrive an [external-secret](https://github.com/alphagov/govuk-dgu-charts/blob/b18247d9e9968778fcdd6e67ccac3a88740b5cc8/charts/datagovuk/templates/_find.tpl#L56). Otherwise if enabled it will set the value to `dummy`
- UID/GID for postgres alpine is [70](https://github.com/docker-library/postgres/blob/master/13/alpine3.21/Dockerfile#L9) so set that everywhere
- https://github.com/alphagov/govuk-dgu-charts/pull/504 incorrectly identifies the postgres user as `999` as this was `bookworm` and not `alpine`