### PR TITLE
Fix email sending for CKAN in integration

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -39,8 +39,8 @@ ckanHelmValues:
         host: "dgu-shared-redis"
       smtp:
         server: "email-smtp.eu-west-1.amazonaws.com:587"
-        user: "AKIATB5RC4XX4VZIWMF7"
-        mailFrom: "team@data.gov.uk"
+        user: "AKIATB5RC4XXWLNAUL36"
+        mailFrom: "datagovuk-ckan@integration.govuk.digital"
         starttls: "True"
       s3:
         useIamServiceAccount: true


### PR DESCRIPTION
This replaces the access key with one that is currently active and swaps out the sending domain to one that the integration AWS account is actually allowed to send from

https://github.com/alphagov/govuk-platform-internal/issues/33