### PR TITLE
feat: add GOVUK_ENVIRONMENT var

### DIFF
--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -13,6 +13,8 @@
   value: datasets-{{ $environment }}
 - name: GOVUK_APP_DOMAIN
   value: "www.gov.uk"
+- name: GOVUK_ENVIRONMENT
+  value: {{ $environment }}
 - name: GOVUK_ENVIRONMENT_NAME
   value: {{ $environment }}
 - name: GOVUK_PROMETHEUS_EXPORTER


### PR DESCRIPTION
- adds the standard variable alongside GOVUK_ENVIRONMENT_NAME, which is now no longer used elsewhere. Once this is deployed to production, we can edit this line: https://github.com/alphagov/datagovuk_find/blob/14b617936a42ba80a4ac6f9234acfe5376e117fb/config/initializers/sentry.rb#L6

  ....and then remove the mention of GOVUK_ENVIRONMENT_NAME here.