### PR TITLE
feat: remove GOVUK_ENVIRONMENT_NAME var

### DIFF
--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -15,8 +15,6 @@
   value: "www.gov.uk"
 - name: GOVUK_ENVIRONMENT
   value: {{ $environment }}
-- name: GOVUK_ENVIRONMENT_NAME
-  value: {{ $environment }}
 - name: GOVUK_PROMETHEUS_EXPORTER
   value: "force"
 - name: GOVUK_WEBSITE_ROOT


### PR DESCRIPTION
- This isn't used by datagovuk_find any more: https://github.com/alphagov/datagovuk_find/pull/1500
- Replaced by GOVUK_ENVIRONMENT https://github.com/alphagov/govuk-dgu-charts/pull/535