### PR TITLE
Fix templating for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Now your local CKAN deployment will use the `localhost:54392/ckan.2.10.4` image.
 10. Update the `/etc/hosts` file as follows
 
 ```sh
-127.0.0.1	localhost find.data.gov.uk ckan.dev.govuk.digital
+127.0.0.1	localhost find.data.gov.uk ckan.eks.test.govuk.digital
 ```
 
 `datagovuk-find` can be accessed at `find.data.gov.uk:8081`
-`ckan` can be accessed at `ckan.dev.govuk.digital:8081`
+`ckan` can be accessed at `ckan.eks.test.govuk.digital:8081`
 
 #### Test Helm chart in EKS
 

--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -1,8 +1,8 @@
 {{- define "ckan.environment-variables" -}}
-{{- $environment := eq $.Values.environment "test" | ternary "development" $.Values.environment -}}
 {{- $ephemeralPath := print $.Values.argo_environment ".ephemeral.govuk.digital" }}
-{{- $stablePath := eq "production" $environment | ternary "publishing.service.gov.uk" (print $environment ".publishing.service.gov.uk")}}
-{{- $environmentPath := eq "ephemeral" $environment | ternary $ephemeralPath $stablePath -}}
+{{- $stablePath := eq "production" $.Values.environment | ternary "publishing.service.gov.uk" (print $.Values.environment ".publishing.service.gov.uk")}}
+{{- $localOrStablePath := eq "test" $.Values.environment | ternary "http://ckan.eks.test.govuk.digital:8081" (print "https://ckan." $stablePath) }}
+{{- $environmentPath := eq "ephemeral" $.Values.environment | ternary (print "https://ckan." $ephemeralPath) $localOrStablePath -}}
 {{- with .Values.ckan.config }}
 - name: CKAN_SQLALCHEMY_URL
 {{- if $.Values.dev.enabled }}
@@ -40,7 +40,7 @@
 - name: CKAN_SITE_ID
   value: {{ .site.id }}
 - name: CKAN_SITE_URL
-  value: https://ckan.{{- $environmentPath }}
+  value: {{ $environmentPath }}
 - name: CKAN_SMTP_SERVER
   value: {{ .smtp.server }}
 - name: CKAN_SMTP_STARTTLS


### PR DESCRIPTION
Templating for CKAN env vars was broken for the local development cluster due to changes put in to support the ephemeral environment, so fix the templating and update the README with the correct way to access the CKAN website on your machine.
