### PR TITLE
Update external-secrets apiVersion to v1 from v1beta1

### DIFF
--- a/charts/ckan/templates/external-secret.yaml
+++ b/charts/ckan/templates/external-secret.yaml
@@ -1,6 +1,6 @@
 {{- with .Values.externalSecret }}
 {{- if .enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: "{{ .name }}"

--- a/charts/datagovuk/templates/external-secret.yaml
+++ b/charts/datagovuk/templates/external-secret.yaml
@@ -1,6 +1,6 @@
 {{- with .Values.externalSecret }}
 {{- if .enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: "{{ .name }}"


### PR DESCRIPTION
This changes the apiVersion of everything using externalsecrets to v1 from v1beta1, this what [the external-secrets changelog for v0.17.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) says to do.

See https://github.com/alphagov/govuk-helm-charts/pull/3473 for a more in-depth proof this is safe.

That PR has also been applied, along with all of our other versioned charts (cluster-secrets, cluster-secrets-store etc)