### PR TITLE
BAU - Enable memory limits and resources for ckan deployment

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -2,6 +2,11 @@ ckanHelmValues:
   environment: integration
   arch: arm64
   ckan:
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
     args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
     ingress:
       host: ckan.eks.integration.govuk.digital

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -2,6 +2,11 @@ ckanHelmValues:
   environment: production
   arch: arm64
   ckan:
+    appResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 3Gi
     replicaCount: 2
     ingress:
       host: ckan.eks.production.govuk.digital

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -2,6 +2,11 @@ ckanHelmValues:
   environment: staging
   arch: arm64
   ckan:
+    appResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 3Gi
     replicaCount: 1
     ingress:
       host: ckan.eks.staging.govuk.digital

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -70,6 +70,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+          {{- with .Values.ckan.appResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
           {{- if .Values.ckan.probes.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -121,6 +121,13 @@ ckan:
       - "/action/package_search"
       - "/action/package_list"
       - "/action/harvest_source_list"
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 50m
+        memory: 512Mi
 
 solr:
   enabled: true


### PR DESCRIPTION
Description:
- Memory usage for ckan in production showed a spike of 2.5G so requests and limits are set appropriately
- Memory usage for ckan in staging showed a spike of 2G so requests and limits are set appropriately
- Memory usage for ckan in integration peaked around 200Mb so requests and limits are set appropriately
- nginx memory usage in all environments is negligible
- https://github.com/alphagov/govuk-dgu-charts/issues/121