### PR TITLE
BAU - Add CODEOWNERS file and ephemeral environment resource limits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Anyone with write access can merge by default
+*
+
+# Platform Engineering review required
+# GitHub Actions workflows and repo config
+/.github/ @alphagov/gov-uk-platform-engineering
+# Helm Charts
+/charts/ @alphagov/gov-uk-platform-engineering
+
+# Allow changes to non-prod app values
+/charts/app-of-apps/values-integration.yaml
+/charts/app-of-apps/values-staging.yaml
+/charts/app-of-apps/values-ephemeral.yaml

--- a/charts/app-of-apps/values-ephemeral.yaml
+++ b/charts/app-of-apps/values-ephemeral.yaml
@@ -2,6 +2,11 @@ ckanHelmValues:
   environment: ephemeral
   arch: arm64
   ckan:
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
     args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
     ingress:
       ingressClassName: aws-alb


### PR DESCRIPTION
Description:
- Ephemeral environment limits are identical to integration
- Add CODEOWNERS file
- https://github.com/alphagov/govuk-dgu-charts/issues/121