### PR TITLE
BAU - Enable solr resource limits and requests

### DIFF
--- a/charts/app-of-apps/values-ephemeral.yaml
+++ b/charts/app-of-apps/values-ephemeral.yaml
@@ -52,6 +52,11 @@ ckanHelmValues:
     probes:
       enabled: true
   solr:
+    appResources:
+      limits:
+        memory: 3Gi
+      requests:
+        memory: 2Gi
     enabled: true
     persistence:
       enabled: true

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -61,6 +61,11 @@ ckanHelmValues:
     probes:
       enabled: true
   solr:
+    appResources:
+      limits:
+        memory: 3Gi
+      requests:
+        memory: 2Gi
     enabled: true
     persistence:
       enabled: true

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -66,6 +66,11 @@ ckanHelmValues:
     probes:
       enabled: true
   solr:
+    appResources:
+      limits:
+        memory: 3Gi
+      requests:
+        memory: 2Gi
     enabled: true
     persistence:
       enabled: true

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -62,6 +62,11 @@ ckanHelmValues:
     probes:
       enabled: true
   solr:
+    appResources:
+      limits:
+        memory: 3Gi
+      requests:
+        memory: 2Gi
     enabled: true
     persistence:
       enabled: true

--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -65,9 +65,10 @@ spec:
               port: solr
             initialDelaySeconds: 10
             periodSeconds: 3
+          {{- with .Values.ckan.appResources }}
           resources:
-            requests:
-              memory: 1500Mi
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
       {{- if .Values.solr.persistence.enabled }}
       volumes:
         - name: data

--- a/charts/dgu-shared/templates/redis/statefulset.yaml
+++ b/charts/dgu-shared/templates/redis/statefulset.yaml
@@ -28,6 +28,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+          {{- with .Values.redis.resources }}
+          resources:
+            {{  . | toYaml | trim | nindent 12 }}
+          {{- end }}
       {{- if .Values.redis.persistence.enabled }}
       volumes:
         - name: data


### PR DESCRIPTION
Description:
- solr is averageing 1GB of memory over 7 weeks so set request to 2GB and limit to 3GB
- Turn on solr resource limits and requests
- Turn on redis resource limits and requests as https://github.com/alphagov/govuk-dgu-charts/pull/553 only added to `values.yaml`
- https://github.com/alphagov/govuk-dgu-charts/issues/121