### PR TITLE
BAU - Enable pycsw resource limits

### DIFF
--- a/charts/app-of-apps/values-ephemeral.yaml
+++ b/charts/app-of-apps/values-ephemeral.yaml
@@ -51,6 +51,11 @@ ckanHelmValues:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:
       enabled: true
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
   solr:
     appResources:
       limits:

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -60,6 +60,11 @@ ckanHelmValues:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:
       enabled: true
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
   solr:
     appResources:
       limits:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -65,6 +65,11 @@ ckanHelmValues:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:
       enabled: true
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
   solr:
     appResources:
       limits:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -61,6 +61,11 @@ ckanHelmValues:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:
       enabled: true
+    appResources:
+      limits:
+        memory: 2Gi
+      requests:
+        memory: 1Gi
   solr:
     appResources:
       limits:

--- a/charts/ckan/templates/pycsw/deployment.yaml
+++ b/charts/ckan/templates/pycsw/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+          {{- with .Values.pycsw.appResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
           {{- if .Values.pycsw.probes.enabled }}
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Description:
- pycsw is averaging 500 Mb memory usage so set limits and resources appropriately
- https://github.com/alphagov/govuk-dgu-charts/issues/121