### PR TITLE
[DGUK-274] Add basic auth to find

### DIFF
--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -45,6 +45,11 @@
     secretKeyRef:
       name: {{ .basicAuthPasswordSecretKeyRef.name }}
       key: {{ .basicAuthPasswordSecretKeyRef.key }}
+- name: BASIC_AUTH_BYPASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthBypassSecretKeyRef.name }}
+      key: {{ .basicAuthBypassSecretKeyRef.key }}
 {{- end }}
 {{- with .gaTrackingId }}
 - name: GA_TRACKING_ID

--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -34,6 +34,22 @@
 - name: RATE_LIMIT_PERIOD
   value: "{{ .Values.find.config.rateLimitPeriod }}"
 {{- with .Values.find.config }}
+{{ if and (ne $environment "development") (ne $environment "production") }}
+- name: BASIC_AUTH_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthNameSecretKeyRef.name }}
+      key: {{ .basicAuthNameSecretKeyRef.key }}
+- name: BASIC_AUTH_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthPasswordSecretKeyRef.name }}
+      key: {{ .basicAuthPasswordSecretKeyRef.key }}
+{{- end }}
+- name: RATE_LIMIT_COUNT
+  value: "{{ .rateLimitCount }}"
+- name: RATE_LIMIT_PERIOD
+  value: "{{ .rateLimitPeriod }}"
 {{- with .gaTrackingId }}
 - name: GA_TRACKING_ID
   value: {{ . }}

--- a/charts/datagovuk/templates/_find.tpl
+++ b/charts/datagovuk/templates/_find.tpl
@@ -46,10 +46,6 @@
       name: {{ .basicAuthPasswordSecretKeyRef.name }}
       key: {{ .basicAuthPasswordSecretKeyRef.key }}
 {{- end }}
-- name: RATE_LIMIT_COUNT
-  value: "{{ .rateLimitCount }}"
-- name: RATE_LIMIT_PERIOD
-  value: "{{ .rateLimitPeriod }}"
 {{- with .gaTrackingId }}
 - name: GA_TRACKING_ID
   value: {{ . }}

--- a/charts/datagovuk/templates/find/deployment.yaml
+++ b/charts/datagovuk/templates/find/deployment.yaml
@@ -51,14 +51,14 @@ spec:
             timeoutSeconds: 60
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             periodSeconds: 5
             successThreshold: 3
             timeoutSeconds: 30
           startupProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 60
             failureThreshold: 60

--- a/charts/datagovuk/templates/find/frontend-deployment.yaml
+++ b/charts/datagovuk/templates/find/frontend-deployment.yaml
@@ -51,14 +51,14 @@ spec:
             timeoutSeconds: 60
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             periodSeconds: 5
             successThreshold: 3
             timeoutSeconds: 30
           startupProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 60
             failureThreshold: 60

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -54,6 +54,9 @@ find:
     basicAuthPasswordSecretKeyRef:
       name: datagovuk
       key: basic_auth_password
+    basicAuthBypassSecretKeyRef:
+      name: datagovuk
+      key: basic_auth_bypass
     rateLimitCount: "100"
     rateLimitPeriod: "60"
 

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -48,6 +48,12 @@ find:
     findSentryDsnSecretKeyRef:
       name: datagovuk
       key: find_sentry_dsn
+    basicAuthNameSecretKeyRef:
+      name: datagovuk
+      key: basic_auth_name
+    basicAuthPasswordSecretKeyRef:
+      name: datagovuk
+      key: basic_auth_password
     rateLimitCount: "100"
     rateLimitPeriod: "60"
 

--- a/local-dev.yaml
+++ b/local-dev.yaml
@@ -16,3 +16,13 @@ type: Opaque
 stringData:
   aws_access_key_id: "test"
   aws_secret_access_key: "test"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datagovuk
+  namespace: datagovuk
+type: Opaque
+stringData:
+  basic_auth_name: "admin"
+  basic_auth_password: "password"


### PR DESCRIPTION
Add capability to protect find app with basic auth.  This will initially be switched on in staging and integration.

Companion PR: https://github.com/alphagov/datagovuk_find/pull/1593