### PR TITLE
Add PodMonitor for datagovuk-frontend-find

### DIFF
--- a/charts/datagovuk/templates/find/podmonitor.yaml
+++ b/charts/datagovuk/templates/find/podmonitor.yaml
@@ -14,4 +14,20 @@ spec:
       app: {{ .Release.Name }}-find
   podMetricsEndpoints:
   - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-frontend-find
+  labels:
+    app: {{ .Release.Name }}-frontend-find
+    helm.sh/chart: govuk-dgu-charts
+    app.kubernetes.io/name: frontend-find
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-frontend-find
+  podMetricsEndpoints:
+  - port: metrics
 {{- end }}


### PR DESCRIPTION
## Summary

- `datagovuk-frontend-find` (collections/MVP frontend) had no PodMonitor, hence Prometheus was not scraping its metrics

- impossible to distinguish response time and error rate between the directory and collections services in Grafana

- Adds a second PodMonitor alongside the existing `datagovuk-find` one

## Test plan

- [ ] Verify both PodMonitors render correctly: `helm template charts/datagovuk --show-only templates/find/podmonitor.yaml`

- [ ] After deploy, confirm `datagovuk-frontend-find` appears as a separate series in Grafana response time panels

Relates to [DGUK-359](https://cddodatamarketplace.atlassian.net/browse/DGUK-359)