### PR TITLE
Add an external secret for readonly database credentials

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -94,6 +94,8 @@ ckanHelmValues:
     replicaCount: 1
   externalSecret:
     enabled: true
+  externalReadonlySecret:
+    enabled: true
 datagovukHelmValues:
   environment: integration
   arch: arm64

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -101,6 +101,8 @@ ckanHelmValues:
         memory: 1Gi
   externalSecret:
     enabled: true
+  externalReadonlySecret:
+    enabled: true
 datagovukHelmValues:
   environment: production
   arch: arm64

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -96,6 +96,8 @@ ckanHelmValues:
         memory: 1Gi
   externalSecret:
     enabled: true
+  externalReadonlySecret:
+    enabled: true
 datagovukHelmValues:
   arch: arm64
   environment: staging

--- a/charts/ckan/templates/external-readonly-secret.yaml
+++ b/charts/ckan/templates/external-readonly-secret.yaml
@@ -1,0 +1,18 @@
+{{- with .Values.externalReadonlySecret }}
+{{- if .enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "{{ .name }}"
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    {{- toYaml .secretStoreRef | trim | nindent 4 }}
+  dataFrom:
+    - extract:
+        key: {{ .key }}
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+{{- end }}
+{{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -177,6 +177,15 @@ externalSecret:
     name: aws-secretsmanager
     kind: ClusterSecretStore
 
+# The naming of this secret and key follow the wider GOV.UK standardised naming
+externalReadonlySecret:
+  enabled: false
+  name: ckan-postgres-readonly
+  key: govuk/ckan/postgres-readonly
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+
 monitoring:
   enabled: false
   metricsPort: 9394


### PR DESCRIPTION
This PR adds in the config for the readonly database secrets. I followed the pattern of the existing external secret.

The name of the secret, and the key it loads from, follows the wider GOV.UK naming for these which will mean anything we make to automate use of this will be usable by DGU/NDL too :) 