### PR TITLE
DGUK-434: Apply Harvest gather HA config to production

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -86,12 +86,16 @@ ckanHelmValues:
   dev:
     enabled: false
   gather:
-    replicaCount: 1
+    replicaCount: 2
+    probes:
+      enabled: true
     appResources:
       limits:
-        memory: 3Gi
+        memory: 4Gi
+        cpu: 2
       requests:
         memory: 2Gi
+        cpu: 500m
   fetch:
     replicaCount: 1
     appResources:


### PR DESCRIPTION
- replicaCount: 1 -> 2 (high availability)
- probes.enabled: true (pgrep liveness/readiness/startup probes)
- memory limit: 3Gi -> 4Gi (address OOMKilled restarts)
- Add cpu limits: 2 / requests: 500m

Production was OOMKilled 39 times in 45h. 

Staging verified stable at 0 restarts over 45h with same config under real reharvest load.