### PR TITLE
DGUK-60: Rightsize production components to 25 req/s capacity

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -4,9 +4,9 @@ ckanHelmValues:
   ckan:
     appResources:
       limits:
-        memory: 4Gi
+        memory: 2Gi
       requests:
-        memory: 3Gi
+        memory: 1Gi
     args: ["gunicorn -c $CKAN_CONFIG/gunicorn_config.py --bind 0.0.0.0:5000 wsgi:application --timeout 120 --workers 4"]
     replicaCount: 2
     ingress:
@@ -74,13 +74,14 @@ ckanHelmValues:
   solr:
     appResources:
       limits:
-        memory: 3Gi
-      requests:
         memory: 2Gi
+      requests:
+        memory: 1Gi
     enabled: true
     persistence:
       enabled: true
       persistentVolumeClaimName: solr
+      size: 2Gi
   postgres:
     enabled: false
   dev:
@@ -91,18 +92,18 @@ ckanHelmValues:
       enabled: true
     appResources:
       limits:
-        memory: 4Gi
-        cpu: 2
+        memory: 1Gi
+        cpu: 1
       requests:
-        memory: 2Gi
-        cpu: 500m
+        memory: 512Mi
+        cpu: 250m
   fetch:
     replicaCount: 1
     appResources:
       limits:
-        memory: 2Gi
-      requests:
         memory: 1Gi
+      requests:
+        memory: 512Mi
   externalSecret:
     enabled: true
   externalReadonlySecret:
@@ -113,10 +114,10 @@ datagovukHelmValues:
   find:
     appResources:
       limits:
-        memory: 4Gi
-      requests:
         memory: 2Gi
-    replicaCount: 3
+      requests:
+        memory: 1Gi
+    replicaCount: 2
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     config:
       gaTrackingId: UA-10855508-1
@@ -152,3 +153,12 @@ dguSharedHelmValues:
   arch: arm64
   redis:
     replicaCount: 1
+    resources:
+      limits:
+        cpu: 250m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    persistence:
+      size: 1Gi


### PR DESCRIPTION


Rightsize production Kubernetes resource requests and limits to match the agreed 25 req/s capacity target, validated by load testing on staging.



Production resources were set at initial deployment and never revisited. Observed utilisation is far below allocation:
- Solr PVC: < 10% volume used
- Redis PVC: < 0.2% volume used

Oversized resource requests inflate EKS node costs by preventing efficient pod bin-packing.

## Changes

| Component | Setting | Before | After |
|---|---|---|---|
| CKAN | memory limit | 4Gi | 2Gi |
| CKAN | memory request | 3Gi | 1Gi |
| Solr | memory limit | 3Gi | 2Gi |
| Solr | memory request | 2Gi | 1Gi |
| Gather | memory limit | 4Gi | 1Gi || Gather | memory limit | 4Gi | 1Gi || Gather | memory limit | 4Gi | 1Gi || Gather | memory limit | 4Gi | 1Gi || Gather | memmory limit || Gather | memory limit | 4ry request| Gather | memory limit | 4Gi | 1Gi || Gather | memory limit | 4Giry request | 2Gi | 1Gi |



