### PR TITLE
DGUK-60: Rightsize integration gather and solr to 25 req/s capacity

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -67,13 +67,14 @@ ckanHelmValues:
   solr:
     appResources:
       limits:
-        memory: 3Gi
-      requests:
         memory: 2Gi
+      requests:
+        memory: 1Gi
     enabled: true
     persistence:
       enabled: true
       persistentVolumeClaimName: solr
+      size: 2Gi
   postgres:
     enabled: false
   dev:
@@ -84,11 +85,11 @@ ckanHelmValues:
       enabled: true
     appResources:
       limits:
-        memory: 4Gi
-        cpu: 2
+        memory: 1Gi
+        cpu: 1
       requests:
-        memory: 2Gi
-        cpu: 500m
+        memory: 512Mi
+        cpu: 250m
   fetch:
     appResources:
       limits:


### PR DESCRIPTION

Rightsize integration gather and Solr resource requests and limits to match the agreed 25 req/s capacity target, consistent with the staging and production changes.



Integration gather and Solr resources were set above the staged and validated rightsizing targets:
- Gather: 4Gi memory limit, 2 cpu — well above what is needed for the integration workload
- Solr: 3Gi memory limit — index data is < 10% of allocation

## Changes

| Component | Setting | Before | After |
|---|---|---|---|
| Gather | memory limit | 4Gi | 1Gi |
| Gather | memory request | 2Gi | 512Mi |
| Gather | cpu limit | 2 | 1 |
| Gather | cpu request | 500m | 250m |
| Solr | memory limit | 3Gi | 2Gi |
| Solr | memory request | 2Gi | 1Gi |


## Validation

These settings were validated on staging via a 35-minute k6 load test at 45 VUs (~28 req/s) with 0 pod restarts and 0 OOMKills.

