### PR TITLE
DGUK-60: Remove Solr persistence.size from production and integration

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -74,7 +74,6 @@ ckanHelmValues:
     persistence:
       enabled: true
       persistentVolumeClaimName: solr
-      size: 2Gi
   postgres:
     enabled: false
   dev:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -81,7 +81,6 @@ ckanHelmValues:
     persistence:
       enabled: true
       persistentVolumeClaimName: solr
-      size: 2Gi
   postgres:
     enabled: false
   dev:


### PR DESCRIPTION
## Problem

ArgoCD sync is failing on production with:

```
PersistentVolumeClaim "solr" is invalid: spec.resources.requests.storage:
Forbidden: field can not be less than status.capacity
```

Previous PR set `solr.persistence.size: 2Gi` in `values-production.yaml` and `values-integration.yaml`. However the existing Solr EBS PVCs were provisioned at `10Gi`. Kubernetes forbids shrinking a PVC's storage request in-place.


## Fix

Remove the `size: 2Gi` line from the Solr `persistence` block in both files. The PVC template (`charts/ckan/templates/solr/pvc.yaml`) defaults to `10Gi`