### PR TITLE
Do not set the redis persistent volume size

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -159,5 +159,3 @@ dguSharedHelmValues:
       requests:
         cpu: 100m
         memory: 128Mi
-    persistence:
-      size: 1Gi

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -157,8 +157,6 @@ dguSharedHelmValues:
       requests:
         cpu: 100m
         memory: 128Mi
-    persistence:
-      size: 1Gi
 
 # Load test chart — staging only, intentionally absent from values-production.yaml
 loadTestConfig:

--- a/charts/dgu-shared/values.yaml
+++ b/charts/dgu-shared/values.yaml
@@ -19,4 +19,3 @@ redis:
   persistence:
     enabled: true
     persistentVolumeClaimName: "redis"
-    size: 1Gi


### PR DESCRIPTION
It cannot be set to be lower than previous capacity without deleting the persistent volume