### PR TITLE
DGUK-60: Remove Solr persistence.size from staging

### DIFF
--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -76,7 +76,6 @@ ckanHelmValues:
     persistence:
       enabled: true
       persistentVolumeClaimName: solr
-      size: 2Gi
   postgres:
     enabled: false
   dev:


### PR DESCRIPTION
## Problem

Same issue as PR #732 (which fixed production and integration) but for staging.

`values-staging.yaml` still has `solr.persistence.size: 2Gi`. The existing Solr EBS PVC in staging was provisioned at `10Gi`. ArgoCD will fail to sync with:

```
PersistentVolumeClaim "solr" is invalid: spec.resources.requests.storage:
Forbidden: field can not be less than status.capacity
```

## Fix

Removed `size: 2Gi` from the Solr `persistence` block in `values-staging.yaml`. The Solr memory rightsizing (`limits: 2Gi` / `requests: 1Gi`) is retained — only the PVC size override is removed.

## Files changed

- `charts/app-of-apps/values-staging.yaml` — removed `solr.persistence.size: 2Gi`

