### PR TITLE
DGUK-486 Add slack notifications for datagovuk apps

### DIFF
--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: cluster-services
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ .Values.datagovukHelmValues.slackChannel }}
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.datagovukHelmValues.slackChannel }}
 spec:
   project: datagovuk
   source:

--- a/charts/app-of-apps/templates/datagovuk-application.yaml
+++ b/charts/app-of-apps/templates/datagovuk-application.yaml
@@ -6,6 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
+    slackChannel: {{ .Values.datagovukHelmValues.slackChannel | quote }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ .Values.datagovukHelmValues.slackChannel }}
     notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ .Values.datagovukHelmValues.slackChannel }}
 spec:

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -102,6 +102,7 @@ ckanHelmValues:
     enabled: true
 datagovukHelmValues:
   environment: integration
+  slackChannel: "#datagovuk-technical"
   arch: arm64
   find:
     appResources:


### PR DESCRIPTION
Add slack notifications for datagovuk_find app to integration

Sends success and failure slack messages on sync


based on [govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts/blob/f21102a84c787400f52b4fad92b9a17be67c9bd4/charts/app-config/values.yaml#L15) and https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/services/slack/