### PR TITLE
Update datagovuk healthcheck to /health/

### DIFF
--- a/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               drop: ["ALL"]
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/
               port: http
               httpHeaders:
                 - name: host
@@ -57,7 +57,7 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/
               port: http
               httpHeaders:
                 - name: host


### PR DESCRIPTION
/health does a redirect to /health/ which does not have a host header defined. 

Set the healthcheck to /health/ so no redirect needed

https://cddodatamarketplace.atlassian.net/browse/DGUK-509