### PR TITLE
Update datagovuk image tags for integration (1486272596c7dd7b9c52b564ff13591d39f1a27c)

### DIFF
--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -1,0 +1,24 @@
+name: Auto-Approve Image Tag Updates
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
+    
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Set up GitHub CLI
+        uses: cli/gh-action@v2
+
+      - name: Approve the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --approve \
+            --body "Automated approval for integration image tag update."

--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Set up GitHub CLI
-        uses: cli/gh-action@v2
+        uses: actions/setup-gh@v4
 
       - name: Approve the PR
         env:


### PR DESCRIPTION
Automatically merge datagovuk integration image tag updates.

This is so that we can automate the ci/cd pipeline