### PR TITLE
Update datagovuk image tags for integration (Testing automatic approvals)

### DIFF
--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -1,0 +1,27 @@
+name: Auto-Approve Image Tag Updates
+on:
+  pull_request:
+    types: [opened]
+  push:
+    branches:
+      - DGUK-506-automatically-merge-datagovuk-integration
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
+    
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Approve the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --approve \
+            --body "Automated approval for datagovuk integration image tag updates."

--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -2,9 +2,6 @@ name: Auto-Approve Image Tag Updates
 on:
   pull_request:
     types: [opened]
-  push:
-    branches:
-      - DGUK-506-automatically-merge-datagovuk-integration
 
 jobs:
   auto-approve:


### PR DESCRIPTION
~Automatically merge datagovuk integration image tag updates.~

~This is so that we can automate the ci/cd pipeline~

~Use github actions bot to do this~


~**Must Do**~
~- [ ] Remove the `on.push:` section in the github action workflow~


I think there's overlapping work: https://github.com/alphagov/govuk-dgu-charts/pull/753

I think the https://github.com/alphagov/govuk-dgu-charts/pull/753 is a better implementation and should be used