### PR TITLE
DGUK-505: Add auto-approve and merge workflow for datagovuk integration deployments

### DIFF
--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -21,7 +21,8 @@ jobs:
     if: |
       startsWith(github.event.pull_request.head.ref, 'ci/') &&
       endsWith(github.event.pull_request.head.ref, '-integration') &&
-      contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
+      contains(github.event.pull_request.title, 'Update datagovuk image tags for integration') &&
+      github.event.pull_request.base.ref == 'main'
 
     permissions:
       pull-requests: write
@@ -32,6 +33,13 @@ jobs:
       # blocks self-approval).  PR_GITHUB_TOKEN is a separate PAT (govuk-ci
       # bot) used here specifically to provide the required second approver
       # identity.
+      - name: Verify PR Author
+        env:
+         PR_GITHUB_TOKEN_USERNAME: ${{ secrets.PR_GITHUB_TOKEN_USERNAME }}
+        run: |
+          if [ "${{ github.event.pull_request.user.login }}" != "$PR_GITHUB_TOKEN_USERNAME" ]; then
+            echo "Unexpected PR author"; exit 1
+          fi
       - name: Approve the PR
         env:
           GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}

--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -3,9 +3,6 @@ name: Auto-Approve and Merge Integration Image Tag Updates
 on:
   pull_request:
     types: [opened]
-    # Restrict to branches created by the CI automation only — this is the
-    # first line of defence against title-injection attacks where an external
-    # actor crafts a matching PR title to trigger an auto-merge into main.
     branches:
       - main
     paths:
@@ -14,10 +11,6 @@ on:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    # Verify both the branch naming convention AND the title — belt-and-braces
-    # guard against title injection.  Branch names are set programmatically by
-    # create-pr.sh (ci/<sha>-integration) so they cannot be spoofed by PR title
-    # alone.
     if: |
       startsWith(github.event.pull_request.head.ref, 'ci/') &&
       endsWith(github.event.pull_request.head.ref, '-integration') &&
@@ -29,10 +22,6 @@ jobs:
       contents: write
 
     steps:
-      # GITHUB_TOKEN cannot approve a PR opened by the same token (GitHub
-      # blocks self-approval).  PR_GITHUB_TOKEN is a separate PAT (govuk-ci
-      # bot) used here specifically to provide the required second approver
-      # identity.
       - name: Verify PR Author
         env:
          PR_GITHUB_TOKEN_USERNAME: ${{ secrets.PR_GITHUB_TOKEN_USERNAME }}
@@ -42,7 +31,7 @@ jobs:
           fi
       - name: Approve the PR
         env:
-          GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review ${{ github.event.pull_request.number }} \
             --approve \

--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -1,0 +1,35 @@
+name: Auto-Approve and Merge Integration Image Tag Updates
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Approve the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --approve \
+            --body "Automated approval for datagovuk integration image tag updates."
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --auto \
+            --merge \
+            --delete-branch

--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -3,27 +3,43 @@ name: Auto-Approve and Merge Integration Image Tag Updates
 on:
   pull_request:
     types: [opened]
+    # Restrict to branches created by the CI automation only — this is the
+    # first line of defence against title-injection attacks where an external
+    # actor crafts a matching PR title to trigger an auto-merge into main.
+    branches:
+      - main
+    paths:
+      - 'charts/datagovuk/images/integration/datagovuk.yaml'
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
+    # Verify both the branch naming convention AND the title — belt-and-braces
+    # guard against title injection.  Branch names are set programmatically by
+    # create-pr.sh (ci/<sha>-integration) so they cannot be spoofed by PR title
+    # alone.
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'ci/') &&
+      endsWith(github.event.pull_request.head.ref, '-integration') &&
+      contains(github.event.pull_request.title, 'Update datagovuk image tags for integration')
 
     permissions:
       pull-requests: write
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
+      # GITHUB_TOKEN cannot approve a PR opened by the same token (GitHub
+      # blocks self-approval).  PR_GITHUB_TOKEN is a separate PAT (govuk-ci
+      # bot) used here specifically to provide the required second approver
+      # identity.
       - name: Approve the PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
         run: |
           gh pr review ${{ github.event.pull_request.number }} \
             --approve \
-            --body "Automated approval for datagovuk integration image tag updates."
+            --body "Automated approval for datagovuk integration image tag updates." \
+            --repo ${{ github.repository }}
 
       - name: Enable auto-merge
         env:
@@ -32,4 +48,5 @@ jobs:
           gh pr merge ${{ github.event.pull_request.number }} \
             --auto \
             --merge \
-            --delete-branch
+            --delete-branch \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
Added .github/workflows/automatic-integration-merge.yaml which triggers on any PR opened with a title matching Update datagovuk image tags for integration, then auto-approves and enables auto-merge.