### PR TITLE
DGUK-505 Use custom bot PAT for merging

### DIFF
--- a/.github/workflows/automatic-integration-merge.yaml
+++ b/.github/workflows/automatic-integration-merge.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --auto \


### PR DESCRIPTION
Use a custom bot / GitHub account to merge integration PRs for `datagovuk` repo

This is because the GitHub token can't merge a pr