### PR TITLE
Add check links cronjob

### DIFF
--- a/charts/ckan/images/test/ckan.yaml
+++ b/charts/ckan/images/test/ckan.yaml
@@ -1,3 +1,3 @@
 repository: ghcr.io/alphagov/ckan
-tag: v1.11.1
+tag: f19f3a57a6eb1d186f93bd0fb5142f586ae53ff3
 branch: main

--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -13,6 +13,15 @@
       name: {{ .sqlalchemyUrlSecretKeyRef.name }}
       key: {{ .sqlalchemyUrlSecretKeyRef.key }}
 {{ end }}
+- name: POSTGRES_URL
+{{- if $.Values.dev.enabled }}
+  value: {{ print "postgresql://ckan:ckan@" $.Release.Name "-postgres/ckan" }}
+{{ else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .sqlalchemyUrlSecretKeyRef.name }}
+      key: {{ .sqlalchemyUrlSecretKeyRef.key }}
+{{ end }}
 - name: CKAN_BEAKER_SESSION_SECRET
 {{- if $.Values.dev.enabled }}
   value: "9EZiPwkeS+cZpqb0VDWrN+Q0M"

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -136,6 +136,10 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
+            {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
+            - name: check-links-output
+              mountPath: /output
+            {{- end }}
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -157,6 +161,11 @@ spec:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
         - name: config
           emptyDir: {}
+        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
+        - name: check-links-output
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-check-links-pvc
+        {{- end }}
         - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -136,10 +136,8 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
-            {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
             - name: check-links-output
               mountPath: /output
-            {{- end }}
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -161,11 +159,9 @@ spec:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
         - name: config
           emptyDir: {}
-        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
         - name: check-links-output
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-check-links-pvc
-        {{- end }}
         - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -118,12 +118,10 @@ data:
         }
         {{- end }}
 
-        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
         location /check-links-output {
           autoindex on;
           alias /output;
         }
-        {{- end }}
 
         # deny access to metrics and other api endpoints
         location ~ ^/(api|api/3|metrics) {

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -118,6 +118,13 @@ data:
         }
         {{- end }}
 
+        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
+        location /check-links-output {
+          autoindex on;
+          alias /output;
+        }
+        {{- end }}
+
         # deny access to metrics and other api endpoints
         location ~ ^/(api|api/3|metrics) {
           deny all;

--- a/charts/ckan/templates/cronjobs/check-links-pvc.yaml
+++ b/charts/ckan/templates/cronjobs/check-links-pvc.yaml
@@ -1,4 +1,3 @@
-{{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,4 +8,3 @@ spec:
       storage: {{ .Values.ckan.checkLinks.persistence.size | default "1Gi" }}
   accessModes:
     - ReadWriteOnce
-{{- end }}

--- a/charts/ckan/templates/cronjobs/check-links-pvc.yaml
+++ b/charts/ckan/templates/cronjobs/check-links-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-check-links-pvc
+spec:
+  resources:
+    requests:
+      storage: {{ .Values.ckan.checkLinks.persistence.size | default "1Gi" }}
+  accessModes:
+    - ReadWriteOnce

--- a/charts/ckan/templates/cronjobs/check-links-pvc.yaml
+++ b/charts/ckan/templates/cronjobs/check-links-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,3 +9,4 @@ spec:
       storage: {{ .Values.ckan.checkLinks.persistence.size | default "1Gi" }}
   accessModes:
     - ReadWriteOnce
+{{- end }}

--- a/charts/ckan/templates/cronjobs/check-links.yaml
+++ b/charts/ckan/templates/cronjobs/check-links.yaml
@@ -8,7 +8,8 @@ metadata:
     app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
   schedule: "0 9 * * *"
-  suspend: {{ .Values.suspendCronJobs }}
+  suspend: true
+  concurrencyPolicy: Forbid
   jobTemplate:
     metadata:
       name: {{ .Release.Name }}-check-links
@@ -46,7 +47,6 @@ spec:
               type: RuntimeDefault
           volumes:
             - name: check-links-output
-              # emptyDir: {}
               persistentVolumeClaim:
                 claimName: {{ .Release.Name }}-check-links-pvc
           {{- if eq "arm64" .Values.arch }}

--- a/charts/ckan/templates/cronjobs/check-links.yaml
+++ b/charts/ckan/templates/cronjobs/check-links.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-check-links
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+spec:
+  schedule: "0 9 * * *"
+  suspend: {{ .Values.suspendCronJobs }}
+  jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-check-links
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+    spec:
+      template:
+        metadata:
+          name: {{ .Release.Name }}-check-links
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+        spec:
+          containers:
+            - name: check-links-script
+              image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
+              workingDir: /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts
+              imagePullPolicy: Always
+              command: [ python, check_links.py, --output-dir=/output ]
+              env:
+                {{- include "ckan.environment-variables" . | nindent 16 }}
+              volumeMounts:
+                - name: check-links-output
+                  mountPath: /output
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+            - name: check-links-output
+              # emptyDir: {}
+              persistentVolumeClaim:
+                claimName: {{ .Release.Name }}-check-links-pvc
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -28,6 +28,9 @@ ckan:
   probes:
     enabled: false
   ckanIniConfigMap: ckan-production-ini-2-10
+  checkLinks:
+    persistence:
+      size: 1Gi
   config:
     dbInit: true
     site:

--- a/charts/datagovuk/images/test/datagovuk.yaml
+++ b/charts/datagovuk/images/test/datagovuk.yaml
@@ -1,2 +1,2 @@
 repository: ghcr.io/alphagov/datagovuk
-tag: 6e1308727f1aafd5eb478a25704d98925ad7f564
+tag: 55b6a76e521715ac1070ff6b5afb74b6f447ebe2

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -21,5 +21,9 @@
     secretKeyRef:
       name: {{ .sentryDSNRef.name }}
       key: {{ .sentryDSNRef.key }}
+- name: POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
@@ -49,9 +49,6 @@ spec:
             httpGet:
               path: /health/
               port: http
-              httpHeaders:
-                - name: host
-                  value: {{ .Values.datagovuk.ingress.host }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 10
@@ -59,9 +56,6 @@ spec:
             httpGet:
               path: /health/
               port: http
-              httpHeaders:
-                - name: host
-                  value: {{ .Values.datagovuk.ingress.host }}
             periodSeconds: 5
             successThreshold: 3
             timeoutSeconds: 10


### PR DESCRIPTION
This PR contains a number of fixes and updates

Add in a cronjob to create the check link report - currently suspended in order to analyse the list first
https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-498

Makes available the output of the check-links script
https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-527

Add in a fix to prevent health checks from creating sentry errors 
https://cddodatamarketplace.atlassian.net/browse/DGUK-509?search_id=139f0040-80a6-42ff-80f4-b084996cb991