### PR TITLE
[DGUK-537] Set google tag manager ID on datagovuk deployments

### DIFF
--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -6,6 +6,8 @@
   value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital, www{{ $environment }}.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
+- name: GOOGLE_TAG_MANAGER_ID
+  value: GTM-5WRWCH8X
 {{- if $.Values.dev.enabled }}
 - name: DJANGO_SECURE_SSL_REDIRECT
   value: "False"


### PR DESCRIPTION
This ensures our GTM id is set for deployed datagovuk environments.

We might want to make this configurable per-environment in future, however for now it seems like GTM is set to only allow certain domains to post analytics data - so keeping a single value for all environments seems to be fine.