### PR TITLE
Only allow read only access to the check-links-output volume

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -138,6 +138,7 @@ spec:
           volumeMounts:
             - name: check-links-output
               mountPath: /output
+              readOnly: true # Only allow read access to the check-links output in the nginx container
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf


### PR DESCRIPTION
The nginx container in CKAN deployment should only have readonly access as only the check links cronjob should be writing to it.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/295?selectedIssue=DGUK-538