### PR TITLE
Restrict check links output to integration and local environments

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -136,9 +136,11 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
+            {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
             - name: check-links-output
               mountPath: /output
               readOnly: true # Only allow read access to the check-links output in the nginx container
+            {{- end }}
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -160,9 +162,11 @@ spec:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
         - name: config
           emptyDir: {}
+        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
         - name: check-links-output
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-check-links-pvc
+        {{- end }}
         - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/cronjobs/check-links-pvc.yaml
+++ b/charts/ckan/templates/cronjobs/check-links-pvc.yaml
@@ -7,4 +7,4 @@ spec:
     requests:
       storage: {{ .Values.ckan.checkLinks.persistence.size | default "1Gi" }}
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce


### PR DESCRIPTION
We can't connect CKAN nginx to the check-links volume because it only allows 1 connection in a node which in turn means that in production only 1 CKAN pod is available reducing ability to handle of traffic, so just restrict it to Integration for now.

https://cddodatamarketplace.atlassian.net/browse/DGUK-538