### PR TITLE
DGUK-539 Add datagovuk staging and production image tags

### DIFF
--- a/charts/datagovuk/images/production/datagovuk.yaml
+++ b/charts/datagovuk/images/production/datagovuk.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/datagovuk
+tag: v0.0.0-test
+branch: main

--- a/charts/datagovuk/images/staging/datagovuk.yaml
+++ b/charts/datagovuk/images/staging/datagovuk.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/datagovuk
+tag: v0.0.0-test
+branch: main


### PR DESCRIPTION
[DGUK-539 ticket](https://cddodatamarketplace.atlassian.net/browse/DGUK-539)

- Add datagovuk staging and production image tags.
- Set to a test tag on datagovuk

This is to prepare for the CI/CD [pipeline between datagovuk repo](https://github.com/alphagov/datagovuk/pull/66) and govuk-dgu-charts.

**INFO:** These **will not be** auto approved or auto merged because the git workflow has not been set up to do so.

