### PR TITLE
[DGUK-500] Thread basic auth secrets through to datagovuk container

### DIFF
--- a/charts/datagovuk/images/test/datagovuk.yaml
+++ b/charts/datagovuk/images/test/datagovuk.yaml
@@ -1,2 +1,2 @@
 repository: ghcr.io/alphagov/datagovuk
-tag: 55b6a76e521715ac1070ff6b5afb74b6f447ebe2
+tag: 5899c2fa620b7a0f6b7b64bda3f472445a14a0f5

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -13,6 +13,23 @@
   value: "False"
 {{- end }}
 {{- with .Values.datagovuk.config }}
+{{ if ne $environment "production" }}
+- name: BASIC_AUTH_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthNameSecretKeyRef.name }}
+      key: {{ .basicAuthNameSecretKeyRef.key }}
+- name: BASIC_AUTH_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthPasswordSecretKeyRef.name }}
+      key: {{ .basicAuthPasswordSecretKeyRef.key }}
+- name: BASIC_AUTH_BYPASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .basicAuthBypassSecretKeyRef.name }}
+      key: {{ .basicAuthBypassSecretKeyRef.key }}
+{{- end }}
 - name: DJANGO_SECRET_KEY
   valueFrom: 
     secretKeyRef:

--- a/local-dev.yaml
+++ b/local-dev.yaml
@@ -26,5 +26,6 @@ type: Opaque
 stringData:
   basic_auth_name: "admin"
   basic_auth_password: "password"
+  basic_auth_bypass: "test-header: test-value"
   django_secret_key: "019dbb14-fbfa-73eb-927f-e86288a2bda9"
   datagovuk_sentry_dsn: "https://public@sentry.example.com/1"


### PR DESCRIPTION
This change ensures that the datagovuk container has the basic auth environment variables set on non-production environments.

This would set up basic auth for integration/staging in the same way that we have it for the find rails app.

Companion PR: https://github.com/alphagov/datagovuk/pull/70