### PR TITLE
[DGUK-64] Add sentry environment variables to CKAN

### DIFF
--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -73,6 +73,13 @@
   value: /config/production.ini
 - name: CKAN_REDIS_URL
   value: redis://{{ .redis.host | default (print $.Release.Name "-redis") }}/{{ .redis.dbNumber | default "1" }}
+- name: SENTRY_DSN
+  valueFrom: 
+    secretKeyRef:
+      name: {{ .sentryDSNRef.name }}
+      key: {{ .sentryDSNRef.key }}
+- name: SENTRY_ENVIRONMENT
+  value: {{ $.Values.environment }}
   {{- if $.Values.dev.enabled }}
 - name: CKAN_TEST_SYSADMIN_NAME
   value: ckan_admin_test

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -53,6 +53,9 @@ ckan:
     beakerSessionValidateKeyRef:
       name: ckan
       key: beaker_session_validate_key
+    sentryDSNRef:
+      name: ckan
+      key: ckan_sentry_dsn
     solr:
       url: ""
       user: ""

--- a/local-dev.yaml
+++ b/local-dev.yaml
@@ -16,6 +16,7 @@ type: Opaque
 stringData:
   aws_access_key_id: "test"
   aws_secret_access_key: "test"
+  ckan_sentry_dsn: "https://public@sentry.example.com/1"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Ensure that ckan containers have `SENTRY_DSN` and `SENTRY_ENVIRONMENT` available as environment variables.

This should make ckan start reporting to sentry - I've tested on a local docker copy of ckan that error reporting works as expected when these environment variables are set.

**Note:** We also need to set the `ckan_sentry_dsn` secret in our secret store before merging this.