### PR TITLE
Switch integration staging datagovuk

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -105,7 +105,6 @@ datagovukHelmValues:
   arch: arm64
   datagovuk:
     ingress:
-      host: datagovuk.eks.integration.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -145,7 +145,7 @@ datagovukHelmValues:
               "www.integration.data.gov.uk",
               "integration.data.gov.uk"
           ]}}]
-        alb.ingress.kubernetes.io/conditions.datagovuk-frontend-find: |
+        alb.ingress.kubernetes.io/conditions.datagovuk-datagovuk: |
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "www.integration.data.gov.uk",
               "integration.data.gov.uk"

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -112,7 +112,6 @@ datagovukHelmValues:
   arch: arm64
   datagovuk:
     ingress:
-      host: datagovuk.eks.production.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -147,7 +147,7 @@ datagovukHelmValues:
               "www.staging.data.gov.uk",
               "staging.data.gov.uk"
           ]}}]
-        alb.ingress.kubernetes.io/conditions.datagovuk-frontend-find: |
+        alb.ingress.kubernetes.io/conditions.datagovuk-datagovuk: |
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "www.staging.data.gov.uk",
               "staging.data.gov.uk"

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -107,7 +107,6 @@ datagovukHelmValues:
   environment: staging
   datagovuk:
     ingress:
-      host: datagovuk.eks.staging.govuk.digital
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -3,7 +3,7 @@
 - name: USE_DOCKER
   value: "True"
 - name: DJANGO_ALLOWED_HOSTS
-  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital, www{{ $environment }}.data.gov.uk"
+  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital, find.eks.{{ .Values.environment }}.govuk.digital, www.{{ $environment }}.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
 - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -3,7 +3,7 @@
 - name: USE_DOCKER
   value: "True"
 - name: DJANGO_ALLOWED_HOSTS
-  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital, find.eks.{{ .Values.environment }}.govuk.digital, www.{{ $environment }}.data.gov.uk"
+  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
 - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
@@ -31,8 +31,8 @@ spec:
           ports:
             - name: http
               containerPort: 8000
-            # - name: metrics
-            #   containerPort: {{ .Values.monitoring.metricsPort }}
+            - name: metrics
+              containerPort: {{ .Values.monitoring.metricsPort }}
           env:
              {{ include "datagovuk.environment-variables" . | nindent 12 }}
           {{- with .Values.datagovuk.appResources }}

--- a/charts/datagovuk/templates/datagovuk/ingress.yaml
+++ b/charts/datagovuk/templates/datagovuk/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if eq "production" $.Values.environment }}
 {{- $ephemeralPath := print $.Values.argo_environment ".ephemeral" -}}
 {{- $stablePath := print "eks." $.Values.environment -}}
 {{- $environmentPath := eq "ephemeral" $.Values.environment | ternary $ephemeralPath $stablePath -}}
@@ -25,4 +26,5 @@ spec:
                 name: {{ $.Release.Name }}-datagovuk
                 port:
                   number: 8000
+{{- end }}
 {{- end }}

--- a/charts/datagovuk/templates/datagovuk/podmonitor.yaml
+++ b/charts/datagovuk/templates/datagovuk/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-datagovuk
+  labels:
+    app: {{ .Release.Name }}-datagovuk
+    helm.sh/chart: govuk-dgu-charts
+    app.kubernetes.io/name: datagovuk
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-datagovuk
+  podMetricsEndpoints:
+  - port: metrics

--- a/charts/datagovuk/templates/datagovuk/podmonitor.yaml
+++ b/charts/datagovuk/templates/datagovuk/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if ne "test" $.Values.environment }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -13,3 +14,4 @@ spec:
       app: {{ .Release.Name }}-datagovuk
   podMetricsEndpoints:
   - port: metrics
+{{- end }}

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- if not (empty .annotations) }}
   annotations:
     {{- tpl (toYaml .annotations) $ | trim | nindent 4 }}
+    {{- if ne "production" $.Values.environment }}
+    alb.ingress.kubernetes.io/healthcheck-path: "/health/"
+    {{- end }}
   {{- end }}
 spec:
   {{ if not (empty .ingressClassName) }}

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -32,8 +32,14 @@ spec:
             pathType: Prefix
             backend:
               service:
+              {{- if ne "production" $.Values.environment }}
+                name: {{ $.Release.Name }}-datagovuk
+                port:
+                  number: 8000
+              {{- else }}
                 name: {{ $.Release.Name }}-frontend-find
                 port:
                   number: 3000
+              {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Switch ingress from `datagovuk_find-frontend` to `datagovuk`

This PR also includes other fixes - 

- added a podmonitor
- add a healthcheck annotation for ALB healthchecks to pass
- remove redundant config values as they were confusing

https://cddodatamarketplace.atlassian.net/browse/DGUK-574