### PR TITLE
Switch production datagovuk 2

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -151,7 +151,7 @@ datagovukHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "www.data.gov.uk"
           ]}}]
-        alb.ingress.kubernetes.io/conditions.datagovuk-frontend-find: |
+        alb.ingress.kubernetes.io/conditions.datagovuk-datagovuk: |
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "www.data.gov.uk"
           ]}}]

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -3,7 +3,7 @@
 - name: USE_DOCKER
   value: "True"
 - name: DJANGO_ALLOWED_HOSTS
-  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk"
+  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk,www.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
 - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/datagovuk/templates/datagovuk/ingress.yaml
+++ b/charts/datagovuk/templates/datagovuk/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if eq "production" $.Values.environment }}
+{{- if .Values.datagovuk.ingress.enabled }}
 {{- $ephemeralPath := print $.Values.argo_environment ".ephemeral" -}}
 {{- $stablePath := print "eks." $.Values.environment -}}
 {{- $environmentPath := eq "ephemeral" $.Values.environment | ternary $ephemeralPath $stablePath -}}

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -10,9 +10,7 @@ metadata:
   {{- if not (empty .annotations) }}
   annotations:
     {{- tpl (toYaml .annotations) $ | trim | nindent 4 }}
-    {{- if ne "production" $.Values.environment }}
     alb.ingress.kubernetes.io/healthcheck-path: "/health/"
-    {{- end }}
   {{- end }}
 spec:
   {{ if not (empty .ingressClassName) }}
@@ -35,14 +33,8 @@ spec:
             pathType: Prefix
             backend:
               service:
-              {{- if ne "production" $.Values.environment }}
                 name: {{ $.Release.Name }}-datagovuk
                 port:
                   number: 8000
-              {{- else }}
-                name: {{ $.Release.Name }}-frontend-find
-                port:
-                  number: 3000
-              {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -57,6 +57,8 @@ find:
       - /harvest
       - /user/login
       - /find-assets
+      - /javascript
+      - /search.html
   config:
     ckanDomain: "ckan.publishing.service.gov.uk"
     solrUrl: "http://ckan-dev-solr/solr/ckan"

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -15,7 +15,7 @@ datagovuk:
   replicaCount: 1
   command: ["/bin/sh", "-c", "/start"]
   ingress:
-    enabled: true
+    enabled: false
     host: datagovuk.eks.test.govuk.digital
     ingressClassName: ""
     annotations:


### PR DESCRIPTION
Switch over for production and make the datagovuk ingress disabled by default
Also add in www.data.gov.uk to the DJANGO_ALLOWED_HOSTS as there is no www.production.data.gov.uk

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-574