### PR TITLE
Add check-links nginx deployment

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -28,6 +28,10 @@ ckanHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "ckan.integration.publishing.service.gov.uk"
           ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-check-links-output: |
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.integration.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -32,6 +32,10 @@ ckanHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "ckan.publishing.service.gov.uk"
           ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-check-links-output: |
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -29,6 +29,10 @@ ckanHelmValues:
           [{"field": "host-header", "hostHeaderConfig": { "values": [
               "ckan.staging.publishing.service.gov.uk"
           ]}}]
+        alb.ingress.kubernetes.io/conditions.{{ .Release.Name }}-check-links-output: |
+          [{"field": "host-header", "hostHeaderConfig": { "values": [
+              "ckan.staging.publishing.service.gov.uk"
+          ]}}]
       tls:
         enabled: true
     probes:

--- a/charts/ckan/templates/_env_vars.tpl
+++ b/charts/ckan/templates/_env_vars.tpl
@@ -13,15 +13,6 @@
       name: {{ .sqlalchemyUrlSecretKeyRef.name }}
       key: {{ .sqlalchemyUrlSecretKeyRef.key }}
 {{ end }}
-- name: POSTGRES_URL
-{{- if $.Values.dev.enabled }}
-  value: {{ print "postgresql://ckan:ckan@" $.Release.Name "-postgres/ckan" }}
-{{ else }}
-  valueFrom:
-    secretKeyRef:
-      name: {{ .sqlalchemyUrlSecretKeyRef.name }}
-      key: {{ .sqlalchemyUrlSecretKeyRef.key }}
-{{ end }}
 - name: CKAN_BEAKER_SESSION_SECRET
 {{- if $.Values.dev.enabled }}
   value: "9EZiPwkeS+cZpqb0VDWrN+Q0M"
@@ -109,4 +100,18 @@
       key: {{ .s3.credentials.awsSecretAccessKeySecretKeyRef.key }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+{{- define "check-links.environment-variables" -}}
+- name: CKAN_OUTPUT_BUCKET_NAME
+  value: govuk-ckan-output-{{ $.Values.environment }}
+- name: POSTGRES_URL
+{{- if $.Values.dev.enabled }}
+  value: {{ print "postgresql://ckan:ckan@" $.Release.Name "-postgres/ckan" }}
+{{ else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.ckan.config.sqlalchemyUrlSecretKeyRef.name }}
+      key: {{ $.Values.ckan.config.sqlalchemyUrlSecretKeyRef.key }}
+{{ end }}
 {{- end }}

--- a/charts/ckan/templates/check-links/check-links-nginx-configmap.yaml
+++ b/charts/ckan/templates/check-links/check-links-nginx-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ckan.nginx.configMap.create }}
-{{- $fullName := (print .Release.Name "-ckan") -}}
+{{- $fullName := (print .Release.Name "-check-links-output") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,34 +10,26 @@ metadata:
     app.kubernetes.io/component: nginx
 data:
   nginx.conf: |-
-
     error_log  /dev/stderr warn;
     pid        /tmp/nginx.pid;
-
     events {
       worker_connections  1024;
     }
-
     http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
-
       client_body_temp_path /tmp/client_temp;
       proxy_temp_path       /tmp/proxy_temp_path;
       fastcgi_temp_path     /tmp/fastcgi_temp;
       uwsgi_temp_path       /tmp/uwsgi_temp;
       scgi_temp_path        /tmp/scgi_temp;
-
       proxy_buffer_size 16k;  # Max total size of response headers.
       # n * m = max response size before spooling to disk. p95 response size should
       # fit comfortably within this in order to avoid performance issues.
       proxy_buffers 24 16k;
-
       server_tokens off;
-
       sendfile        on;
       keepalive_timeout  65;
-
       # Default values for response headers. These values are used when the
       # header is not already set on the incoming response.
       # https://serverfault.com/a/598106
@@ -50,7 +42,6 @@ data:
       map $upstream_http_x_content_type_options $x_content_type_options {
         "" "nosniff";
       }
-
       log_format json_event escape=json '{'
         '"@timestamp":"$time_iso8601",'
         '"body_bytes_sent":$body_bytes_sent,'
@@ -71,63 +62,27 @@ data:
         '"upstream_addr":"$upstream_addr",'
         '"upstream_response_time":"$upstream_response_time"'
       '}';
-
-      upstream {{ $fullName }} {
-        server 127.0.0.1:{{ .Values.ckan.appPort }};
-      }
-
       server {
         listen {{ .Values.ckan.nginx.port }};
         proxy_connect_timeout {{ .Values.ckan.nginx.proxyConnectTimeout }};
         proxy_read_timeout    {{ .Values.ckan.nginx.proxyReadTimeout }};
-
         access_log /dev/stdout json_event;
         error_log /dev/stderr;
-
         # Where the response header is already set on the incoming response,
         # these are no-ops. https://serverfault.com/a/598106
         add_header Strict-Transport-Security $strict_transport_security;
         add_header Permissions-Policy $permissions_policy;
         add_header X-Content-Type-Options $x_content_type_options always;
-
         {{- if ( or (ne .Values.environment "production") (eq .Values.ckan.nginx.denyCrawlers true ) ) }}
         add_header X-Robots-Tag "noindex";
         {{- end }}
-
-        location / {
-          proxy_set_header   Host $http_host;
-          proxy_set_header   X-Real-IP $remote_addr;
-          proxy_pass         http://{{ $fullName }};
-          proxy_redirect     off;
-          client_max_body_size {{ .Values.ckan.nginx.clientMaxBodySize }};
-        }
-
         # Endpoint for liveness and readiness checks of the nginx container.
         location = /readyz {
           return 200 'ok\n';
         }
-
-        # allow access to safelist of endpoints
-        {{- range $path := .Values.ckan.nginx.safelist }}
-        location ~ ^/(api|api/3){{ $path }} {
-          proxy_set_header   Host $http_host;
-          proxy_set_header   X-Real-IP $remote_addr;
-          proxy_pass         http://{{ $fullName }}/$uri$is_args$args;
-          proxy_redirect     off;
-          client_max_body_size {{ $.Values.ckan.nginx.clientMaxBodySize }};
-        }
-        {{- end }}
-
-        # deny access to metrics and other api endpoints
-        location ~ ^/(api|api/3|metrics) {
-          deny all;
-          return 403;
-        }
-
-        # deny access to .py files
-        location ~\.py$ {
-            deny all;
-            return 403;
+        location /check-links-output {
+          autoindex on;
+          alias /check_links;
         }
       }
     }

--- a/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
+++ b/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.appEnabled }}
+{{- $fullName := print .Release.Name "-check-links-output" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: app
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $fullName }}
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}
+        app.kubernetes.io/name: {{ $fullName }}
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 900
+        runAsGroup: 900
+        fsGroup: 900
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: download-check-links-output
+          image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
+          workingDir: /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts
+          command: [ python, check_links_download.py ]
+          env:
+            {{- include "check-links.environment-variables" . | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: check-links-output
+              mountPath: /check_links
+      containers:
+        - name: nginx
+          image: "{{ .Values.checklinks.nginx.image.repository }}:{{ .Values.checklinks.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.checklinks.nginx.image.pullPolicy | default "Always" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.checklinks.nginx.port }}
+          livenessProbe: &nginx-probe
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 2
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
+          readinessProbe:
+            <<: *nginx-probe  # Intentionally same path as liveness.
+            failureThreshold: 2
+            timeoutSeconds: 15
+          {{- with .Values.checklinks.nginx.resources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: check-links-output
+              mountPath: /check_links
+              readOnly: true # Only allow read access to the check-links output in the nginx container
+            - name: {{ .Values.checklinks.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-tmp
+              mountPath: /tmp
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
+      volumes:
+        - name: check-links-output
+          emptyDir: {}
+        - name: {{ .Values.checklinks.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+          configMap:
+            name: {{ .Values.checklinks.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
+        - name: nginx-tmp
+          emptyDir: {}
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+{{- end }}

--- a/charts/ckan/templates/check-links/check-links-service.yaml
+++ b/charts/ckan/templates/check-links/check-links-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-check-links-output
+spec:
+  selector:
+    app: {{ .Release.Name }}-check-links-output
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -136,11 +136,6 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
-            {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
-            - name: check-links-output
-              mountPath: /output
-              readOnly: true # Only allow read access to the check-links output in the nginx container
-            {{- end }}
             - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
@@ -162,11 +157,6 @@ spec:
             name: {{ .Release.Name }}-{{ .Values.ckan.ckanIniConfigMap }}
         - name: config
           emptyDir: {}
-        {{- if or (eq "test" .Values.environment) (eq "integration" .Values.environment) }}
-        - name: check-links-output
-          persistentVolumeClaim:
-            claimName: {{ .Release.Name }}-check-links-pvc
-        {{- end }}
         - name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}
           configMap:
             name: {{ .Values.ckan.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/ckan/ingress.yaml
+++ b/charts/ckan/templates/ckan/ingress.yaml
@@ -31,6 +31,13 @@ spec:
                 name: {{ $.Release.Name }}-pycsw
                 port:
                   number: 8000
+          - path: /check-links-output
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-check-links-output
+                port:
+                  number: 8080
   {{- if .tls.enabled }}
   tls:
     - hosts:

--- a/charts/ckan/templates/cronjobs/check-links.yaml
+++ b/charts/ckan/templates/cronjobs/check-links.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
-  schedule: "0 9 * * *"
-  suspend: true
+  schedule: "0 0 * * 0"  # At 00:00 on Sunday
+  suspend: false
   concurrencyPolicy: Forbid
   jobTemplate:
     metadata:
@@ -27,12 +27,12 @@ spec:
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
               workingDir: /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts
               imagePullPolicy: Always
-              command: [ python, check_links.py, --output-dir=/output ]
+              command: [ python, check_links.py, --output-dir=/check_links ]
               env:
-                {{- include "ckan.environment-variables" . | nindent 16 }}
+                {{- include "check-links.environment-variables" . | nindent 16 }}
               volumeMounts:
                 - name: check-links-output
-                  mountPath: /output
+                  mountPath: /check_links
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -47,8 +47,7 @@ spec:
               type: RuntimeDefault
           volumes:
             - name: check-links-output
-              persistentVolumeClaim:
-                claimName: {{ .Release.Name }}-check-links-pvc
+              emptyDir: {}
           {{- if eq "arm64" .Values.arch }}
           tolerations:
             - key: arch

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -141,6 +141,28 @@ ckan:
         cpu: 50m
         memory: 512Mi
 
+checklinks:
+  nginx:
+    image:
+      repository: nginx
+      pullPolicy: Always
+      tag: stable
+    port: 8080
+    proxyConnectTimeout: 2s
+    proxyReadTimeout: 30s
+    clientMaxBodySize: 50M
+    configMap:
+      create: true
+      name: ""
+    denyCrawlers: true
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 50m
+        memory: 512Mi
+
 solr:
   enabled: true
   persistence:


### PR DESCRIPTION
As EFS did not work which would have enabled a ReadWriteMany access to the persistent volume, a decision was made to use s3 to upload the reports after the check links script had run and to download them onto an nginx pod for publishing. 

The check links job will be run once a week on Sunday so that the reports will be ready to review that week, to download the latest reports the nginx pod will need to be terminated to trigger a download of new reports.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-527