### PR TITLE
Add another container to check-links deployment to check for new reports on s3

### DIFF
--- a/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
+++ b/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
@@ -42,7 +42,7 @@ spec:
               command: [ "bash", "-c", "python check_links_has_new_reports.py --s3-dir=check_links/ --mount-path=/check_links" ]
             initialDelaySeconds: 2
             failureThreshold: 3
-            periodSeconds: 5
+            periodSeconds: 14400 # Check every 4 hours
             timeoutSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
+++ b/charts/ckan/templates/check-links/check-links-nginx-deployment.yaml
@@ -30,22 +30,30 @@ spec:
         fsGroup: 900
         seccompProfile:
           type: RuntimeDefault
-      initContainers:
-        - name: download-check-links-output
+      containers:
+        - name: check-new-reports
           image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
           workingDir: /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts
-          command: [ python, check_links_download.py ]
+          command: [ "bash", "-c", ". chart/download-and-wait.sh" ]
           env:
             {{- include "check-links.environment-variables" . | nindent 12 }}
+          livenessProbe:
+            exec:
+              command: [ "bash", "-c", "python check_links_has_new_reports.py --s3-dir=check_links/ --mount-path=/check_links" ]
+            initialDelaySeconds: 2
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           volumeMounts:
+            - name: check-links-script
+              mountPath: /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts/chart
             - name: check-links-output
               mountPath: /check_links
-      containers:
         - name: nginx
           image: "{{ .Values.checklinks.nginx.image.repository }}:{{ .Values.checklinks.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.checklinks.nginx.image.pullPolicy | default "Always" }}
@@ -87,6 +95,9 @@ spec:
               exec:
                 command: ["sleep", "15"] # To allow time for ALB to deregister pod before termination
       volumes:
+        - name: check-links-script
+          configMap:
+            name: {{ $fullName }}-script
         - name: check-links-output
           emptyDir: {}
         - name: {{ .Values.checklinks.nginx.configMap.name | default (printf "%s-nginx-conf" $fullName) }}

--- a/charts/ckan/templates/check-links/check-links-script.yaml
+++ b/charts/ckan/templates/check-links/check-links-script.yaml
@@ -1,0 +1,15 @@
+{{- $fullName := (print .Release.Name "-check-links-output") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-script
+  labels:
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+data:
+  download-and-wait.sh: |-
+    cd /usr/lib/ckan/venv/src/ckanext-datagovuk/bin/python_scripts
+    python check_links_download.py
+
+    # catch termination signals and wait indefinitely until the container is terminated
+    trap : TERM INT; sleep infinity & wait


### PR DESCRIPTION
Update the check-links-output deplioyment to use a livenessProbe to check for new reports on s3, if there is a new report then the probe will fail which will trigger a reload of the pod and a redownload of all the files on s3.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-596

This has been tested on the Integration cluster.