### PR TITLE
Enable solr index clear to run on Integration

### DIFF
--- a/charts/ckan/templates/cronjobs/solr-index-clear.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-clear.yaml
@@ -1,4 +1,4 @@
-{{- if (eq .Values.environment "staging") }}
+{{- if (ne .Values.environment "production") }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
 spec:
-  schedule: "0 5 * * 0"
+  schedule: "0 8 * * 0"
   suspend: {{ .Values.suspendCronJobs }}
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
Now that syncing is happening on Integration, to fully reindex the whole index needs to be cleared down and rebuilt after the sync operation.

https://cddodatamarketplace.atlassian.net/browse/DGUK-691