### PR TITLE
Set search-index rebuild arg to --clear

### DIFF
--- a/charts/ckan/templates/cronjobs/solr-index-clear.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-clear.yaml
@@ -27,7 +27,7 @@ spec:
             - name: ckan
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
               imagePullPolicy: Always
-              command: [ ckan, search-index, rebuild, -c ]
+              command: [ ckan, search-index, rebuild, --clear ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}
               volumeMounts:


### PR DESCRIPTION
-c arg looked like it was clearing the indexes out and rebuilding but is also confusing as it is an arg for config, so set it to --clear for better clarity