### PR TITLE
Block AI training crawlers and meta-externalagent in nginx

### DIFF
--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -60,7 +60,7 @@ ckanHelmValues:
       name: ckan
       iamRoleARN: arn:aws:iam::172025368201:role/ckan-govuk
     nginx:
-      denyCrawlers: false
+      denyCrawlers: true
   pycsw:
     replicaCount: 1
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -67,6 +67,13 @@ data:
         ~*Clickagy                 1;
         ~*serpstatbot              1;
         ~*DataForSeoBot            1;
+        ~*meta-externalagent       1;
+        ~*GPTBot                   1;
+        ~*ClaudeBot                1;
+        ~*Claude-Web               1;
+        ~*anthropic-ai             1;
+        ~*CCBot                    1;
+        ~*ChatGPT-User             1;
       }
       {{- end }}
 

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -74,6 +74,8 @@ data:
         ~*anthropic-ai             1;
         ~*CCBot                    1;
         ~*ChatGPT-User             1;
+        ~*amazon-Quick             1;
+        ~*TalonGDPvalAttachmentGroupExplorer 1;
       }
       {{- end }}
 
@@ -116,7 +118,7 @@ data:
         add_header Permissions-Policy $permissions_policy;
         add_header X-Content-Type-Options $x_content_type_options always;
 
-        {{- if ( or (ne .Values.environment "production") (eq .Values.ckan.nginx.denyCrawlers true ) ) }}
+        {{- if ne .Values.environment "production" }}
         add_header X-Robots-Tag "noindex";
         {{- end }}
 

--- a/charts/ckan/templates/ckan/nginx-configmap.yaml
+++ b/charts/ckan/templates/ckan/nginx-configmap.yaml
@@ -52,7 +52,7 @@ data:
       }
 
       {{- if .Values.ckan.nginx.denyCrawlers }}
-      # Block known aggressive scrapers and crawlers that cause excessive load
+      # Block bots that send too many requests and slow down the app
       map $http_user_agent $is_bad_bot {
         default                   0;
         ~*Bytespider               1;
@@ -119,6 +119,7 @@ data:
         add_header X-Content-Type-Options $x_content_type_options always;
 
         {{- if ne .Values.environment "production" }}
+        # Tell search engines not to index non-production sites
         add_header X-Robots-Tag "noindex";
         {{- end }}
 


### PR DESCRIPTION
GPTBot and ClaudeBot were hitting CKAN production at over 100 rps combined, flooding the /dataset/ endpoint with complex queries and exhausting all gunicorn workers. meta-externalagent (Meta) was also identified previously as causing slow requests.


I have now added GPTBot, ClaudeBot, Claude-Web, anthropic-ai, CCBot, ChatGPT-User, and meta-externalagent to the existing nginx bot block map. They will receive a 403 at nginx level before any request reaches gunicorn, the same as the existing blocked bots.