### PR TITLE
Add datagovuk directory app to Integration

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -109,6 +109,7 @@ datagovukHelmValues:
   arch: arm64
   datagovuk:
     ingress:
+      enabled: true
       ingressClassName: aws-alb
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -5,7 +5,7 @@
 - name: USE_DOCKER
   value: "True"
 - name: DJANGO_ALLOWED_HOSTS
-  value: "datagovuk-directory.eks.{{ .Values.environment }}.govuk.digital,datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk,www.data.gov.uk"
+  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk,www.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
 - name: GOOGLE_TAG_MANAGER_ID

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -5,7 +5,7 @@
 - name: USE_DOCKER
   value: "True"
 - name: DJANGO_ALLOWED_HOSTS
-  value: "datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk,www.data.gov.uk"
+  value: "datagovuk-directory.eks.{{ .Values.environment }}.govuk.digital,datagovuk.eks.{{ .Values.environment }}.govuk.digital,find.eks.{{ .Values.environment }}.govuk.digital,www.{{ $environment }}.data.gov.uk,www.data.gov.uk"
 - name: SENTRY_ENVIRONMENT
   value: {{ $environment }}
 - name: GOOGLE_TAG_MANAGER_ID
@@ -13,10 +13,6 @@
 {{- if $.Values.dev.enabled }}
 - name: DJANGO_SECURE_SSL_REDIRECT
   value: "False"
-{{- end }}
-{{ if eq $environment "integration" }}
-- name: FEATURE_FLAGS_ENABLED
-  value: "solr-search"
 {{- end }}
 {{- with .Values.datagovuk.config }}
 {{ if ne $environment "production" }}

--- a/charts/datagovuk/templates/datagovuk/datagovuk-directory-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-directory-deployment.yaml
@@ -1,0 +1,89 @@
+{{ if eq $.Values.environment "integration" }}
+{{- $fullName := print .Release.Name "-datagovuk-directory" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ $fullName }}
+    app.kubernetes.io/name: {{ $fullName }}
+    app.kubernetes.io/component: app
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.datagovuk.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ $fullName }}
+  template:
+    metadata:
+      labels:
+        app: {{ $fullName }}
+        app.kubernetes.io/name: {{ $fullName }}
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+    spec:
+      containers:
+        - name: datagovuk-directory
+          image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "datagovuk" "files" $.Files) }}'
+          command: {{ .Values.datagovuk.command | toJson }}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: metrics
+              containerPort: {{ .Values.monitoring.metricsPort }}
+          env:
+             {{ include "datagovuk.environment-variables" . | nindent 12 }}
+            - name: FEATURE_FLAGS_ENABLED
+              value: "solr-search"
+          {{- with .Values.datagovuk.appResources }}
+          resources:
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/
+              port: http
+            periodSeconds: 5
+            successThreshold: 3
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: app-tmp
+              mountPath: /app/tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: app-tmp
+          emptyDir: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      {{- if eq "arm64" .Values.arch }}
+      tolerations:
+        - key: arch
+          operator: Equal
+          value: {{ .Values.arch }}
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+{{- end }}

--- a/charts/datagovuk/templates/datagovuk/ingress.yaml
+++ b/charts/datagovuk/templates/datagovuk/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $.Release.Name }}-datagovuk
+                name: {{ $.Release.Name }}-datagovuk-directory
                 port:
                   number: 8000
 {{- end }}

--- a/charts/datagovuk/templates/datagovuk/service.yaml
+++ b/charts/datagovuk/templates/datagovuk/service.yaml
@@ -10,3 +10,16 @@ spec:
       protocol: TCP
       port: 8000
       targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-datagovuk-directory
+spec:
+  selector:
+    app: {{ $.Release.Name }}-datagovuk-directory
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: http

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -36,15 +36,5 @@ spec:
                 name: {{ $.Release.Name }}-datagovuk
                 port:
                   number: 8000
-    - host: datagovuk-directory.{{ $environmentPath }}.govuk.digital
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $.Release.Name }}-datagovuk-directory
-                port:
-                  number: 8000
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/templates/find/ingress.yaml
+++ b/charts/datagovuk/templates/find/ingress.yaml
@@ -36,5 +36,15 @@ spec:
                 name: {{ $.Release.Name }}-datagovuk
                 port:
                   number: 8000
+    - host: datagovuk-directory.{{ $environmentPath }}.govuk.digital
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-datagovuk-directory
+                port:
+                  number: 8000
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Deploy a new app for datagovuk with the solr-search feature flag set so that smoke tests would pass without having to adapt them for feature flags.

This PR also removes the feature flag from Integration deployment.

https://cddodatamarketplace.atlassian.net/browse/DGUK-815