### PR TITLE
Add REDIS_URL for datagovuk app

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -119,6 +119,9 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/load-balancer-attributes: >
           access_logs.s3.enabled=true, access_logs.s3.bucket=govuk-integration-aws-logging, access_logs.s3.prefix=elb/www-datagovuk
+    config:
+      redis:
+        host: "dgu-shared-redis"
   find:
     appResources:
       limits:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -132,6 +132,9 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/load-balancer-attributes: >
           access_logs.s3.enabled=true, access_logs.s3.bucket=govuk-production-aws-logging, access_logs.s3.prefix=elb/www-datagovuk
+    config:
+      redis:
+        host: "dgu-shared-redis"
   find:
     appResources:
       limits:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -127,6 +127,9 @@ datagovukHelmValues:
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/load-balancer-attributes: >
           access_logs.s3.enabled=true, access_logs.s3.bucket=govuk-staging-aws-logging, access_logs.s3.prefix=elb/www-datagovuk
+    config:
+      redis:
+        host: "dgu-shared-redis"
   find:
     appResources:
       limits:

--- a/charts/datagovuk/templates/_datagovuk.tpl
+++ b/charts/datagovuk/templates/_datagovuk.tpl
@@ -48,5 +48,7 @@
       fieldPath: status.podIP
 - name: SOLR_URL
   value: {{ $solr_url }}
+- name: REDIS_URL
+  value: redis://{{ $.Values.datagovuk.config.redis.host | default (print $.Release.Name "-redis") }}/{{ $.Values.datagovuk.config.redis.dbNumber | default "2" }}
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -43,6 +43,10 @@ datagovuk:
       passwordSecretKeyRef:
         name: ckan
         key: solr_password
+    redis:
+      host: "dgu-shared-dev-redis"
+      port: "6379"
+      dbNumber: "2"
 
 find:
   replicaCount: 1


### PR DESCRIPTION
This sets the redis db_number to 2, so that it can use the same redis instance as CKAN without any risk of name clash

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/727?selectedIssue=DGUK-837