### PR TITLE
Add scheduled job for synchronising CKAN database backups

### DIFF
--- a/charts/app-of-apps/values-ephemeral.yaml
+++ b/charts/app-of-apps/values-ephemeral.yaml
@@ -47,6 +47,11 @@ ckanHelmValues:
       enabled: true
       name: ckan
       iamRoleARN: arn:aws:iam::430354129336:role/ckan-eph-aaa113
+    dbBackupSync:
+      enabled: false
+      iamRoleARN: ""
+      sourceS3BucketName: ""
+      targetS3BucketName: ""
   pycsw:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -59,6 +59,11 @@ ckanHelmValues:
       enabled: true
       name: ckan
       iamRoleARN: arn:aws:iam::210287912431:role/ckan-govuk
+    dbBackupSync:
+      enabled: true
+      iamRoleARN: "arn:aws:iam::210287912431:role/ckan-db-backup-xaccount-sync-govuk"
+      sourceS3BucketName: "govuk-integration-database-backups"
+      targetS3BucketName: "integration-account-ckan-backup"
   pycsw:
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]
     probes:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -65,6 +65,11 @@ ckanHelmValues:
       iamRoleARN: arn:aws:iam::172025368201:role/ckan-govuk
     nginx:
       denyCrawlers: false
+    dbBackupSync:
+      enabled: false
+      iamRoleARN: ""
+      sourceS3BucketName: ""
+      targetS3BucketName: ""
   pycsw:
     replicaCount: 1
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -60,6 +60,11 @@ ckanHelmValues:
       enabled: true
       name: ckan
       iamRoleARN: arn:aws:iam::696911096973:role/ckan-govuk
+    dbBackupSync:
+      enabled: false
+      iamRoleARN: ""
+      sourceS3BucketName: ""
+      targetS3BucketName: ""
   pycsw:
     replicaCount: 1
     args: ["gunicorn --bind 0.0.0.0:8000 wsgi:application --timeout 120"]

--- a/charts/ckan/templates/ckan/configmap-2.10.yaml
+++ b/charts/ckan/templates/ckan/configmap-2.10.yaml
@@ -180,9 +180,9 @@ data:
 
     # Harvesting settings
     ckan.harvest.mq.type = redis
-    ckan.harvest.mq.hostname = {{ .Values.ckan.config.redis.host | default (print .Release.Name "-redis") }}
-    ckan.harvest.mq.port = {{ .Values.ckan.config.redis.port | default "6379" }}
-    ckan.harvest.mq.redis_db = {{ .Values.ckan.config.redis.dbNumber | default "1" }}
+    # Omit mq.hostname/port/redis_db so ckanext-harvest uses ckan.redis.url via
+    # Redis.from_url() — redis-py 8 defaults socket_timeout=5s on the direct
+    # Redis() constructor, which breaks the blocking BLPOP call in gather-consumer
 
     # 12 hours timeout
     ckan.harvest.timeout = 720

--- a/charts/ckan/templates/ckan/database-backup-sync-serviceaccount.yaml
+++ b/charts/ckan/templates/ckan/database-backup-sync-serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.ckan.dbBackupSync.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ckan-db-backup-xaccount-sync
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.ckan.dbBackupSync.iamRoleARN }}
+{{ end }}

--- a/charts/ckan/templates/cronjobs/ckan-cross-account-db-backup-sync.yaml
+++ b/charts/ckan/templates/cronjobs/ckan-cross-account-db-backup-sync.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ckan.dbBackupSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-ckan-database-backup-sync
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+  labels:
+    app.kubernetes.io/arch: arm64
+spec:
+  schedule: "0 11 * * 2"
+  suspend: {{ .Values.suspendCronJobs }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-ckan-database-backup-sync
+      labels:
+        app.kubernetes.io/arch: arm64
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          name: {{ .Release.Name }}-ckan-database-backup-sync
+          labels:
+            app.kubernetes.io/arch: arm64
+        spec:
+          serviceAccountName: ckan-db-backup-xaccount-sync
+          containers:
+            - name: db-backup-sync
+              image: "172025368201.dkr.ecr.eu-west-1.amazonaws.com/github/alphagov/govuk/govuk-toolbox-image:v51"
+              imagePullPolicy: Always
+              command: [ "aws", "s3", "sync", "s3://{{.Values.ckan.dbBackupSync.sourceS3BucketName}}/ckan-postgres/", "s3://{{.Values.ckan.dbBackupSync.targetS3BucketName}}/ckan-postgres/" ]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: arm64
+{{ end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -137,6 +137,11 @@ ckan:
       requests:
         cpu: 50m
         memory: 512Mi
+  dbBackupSync:
+    enabled: false
+    iamRoleARN: ""
+    sourceS3BucketName: ""
+    targetS3BucketName: ""
 
 checklinks:
   nginx:


### PR DESCRIPTION
data.gov.uk is moving to its own AWK accounts. Whilst they are in the process of moving, we want to provide them with dumps of the CKAN database to work with.

The job runs at 11am every Tuesday and performs an `aws s3 sync` between the correct prefix in the two buckets