### PR TITLE
Fix ckan-gather CrashLoopBackOff caused by redis-py 8 socket timeout

### DIFF
--- a/charts/ckan/templates/ckan/configmap-2.10.yaml
+++ b/charts/ckan/templates/ckan/configmap-2.10.yaml
@@ -180,9 +180,9 @@ data:
 
     # Harvesting settings
     ckan.harvest.mq.type = redis
-    ckan.harvest.mq.hostname = {{ .Values.ckan.config.redis.host | default (print .Release.Name "-redis") }}
-    ckan.harvest.mq.port = {{ .Values.ckan.config.redis.port | default "6379" }}
-    ckan.harvest.mq.redis_db = {{ .Values.ckan.config.redis.dbNumber | default "1" }}
+    # Omit mq.hostname/port/redis_db so ckanext-harvest uses ckan.redis.url via
+    # Redis.from_url() — redis-py 8 defaults socket_timeout=5s on the direct
+    # Redis() constructor, which breaks the blocking BLPOP call in gather-consumer
 
     # 12 hours timeout
     ckan.harvest.timeout = 720


### PR DESCRIPTION
redis-py 8.0 changed the default socket_timeout from None to 5s when using the Redis() constructor directly. ckanext-harvest's get_connection_redis() uses the constructor when ckan.harvest.mq.hostname is set, giving the gather and fetch consumer pods a 5s socket timeout on their Redis connections.

BLPOP blocks waiting for harvest jobs  with no jobs in queue it exceeds the 5s socket timeout immediately, crashing the pod with:
  redis.exceptions.TimeoutError: Timeout reading from socket

I have now fixed that by removing the mq.hostname/port/redis_db settings from the configmap. Without mq.hostname, ckanext-harvest falls through to Redis.from_url() using ckan.redis.url (already set), which preserves socket_timeout=None and allows BLPOP to block indefinitely as intended.