### PR TITLE
The port was incorrectly set to 9394, it should be 80

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -113,6 +113,8 @@ datagovukHelmValues:
   environment: integration
   arch: arm64
   datagovuk:
+    monitoring:
+      enabled: true
     ingress:
       enabled: true
       ingressClassName: aws-alb

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -127,6 +127,8 @@ datagovukHelmValues:
   environment: production
   arch: arm64
   datagovuk:
+    monitoring:
+      enabled: true
     ingress:
       ingressClassName: aws-alb
       annotations:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -122,6 +122,8 @@ datagovukHelmValues:
   arch: arm64
   environment: staging
   datagovuk:
+    monitoring:
+      enabled: true
     ingress:
       ingressClassName: aws-alb
       annotations:

--- a/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: http
               containerPort: 8000
             - name: metrics
-              containerPort: {{ .Values.monitoring.metricsPort }}
+              containerPort: {{ .Values.datagovuk.monitoring.metricsPort }}
           env:
              {{ include "datagovuk.environment-variables" . | nindent 12 }}
           {{- with .Values.datagovuk.appResources }}

--- a/charts/datagovuk/templates/datagovuk/podmonitor.yaml
+++ b/charts/datagovuk/templates/datagovuk/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if ne "test" $.Values.environment }}
+{{- if .Values.datagovuk.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -14,4 +15,5 @@ spec:
       app: {{ .Release.Name }}-datagovuk
   podMetricsEndpoints:
   - port: metrics
+{{- end }}
 {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -19,6 +19,9 @@ datagovuk:
     host: datagovuk.eks.test.govuk.digital
     ingressClassName: ""
     annotations:
+  monitoring:
+    enabled: false
+    metricsPort: 80
   config:
     basicAuthNameSecretKeyRef:
       name: datagovuk


### PR DESCRIPTION
For now set the port to 80 so that metrics can be picked up from datagovuk app, we probably want to update the app to use 9394 so that metrics are internal only

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/727?selectedIssue=DGUK-865