### PR TITLE
Fix harvest-gather crash-loop by increasing memory limits

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -93,11 +93,11 @@ ckanHelmValues:
       enabled: true
     appResources:
       limits:
-        memory: 1Gi
+        memory: 2Gi
         cpu: 1
       requests:
-        memory: 512Mi
-        cpu: 250m
+        memory: 1Gi
+        cpu: 500m
   fetch:
     appResources:
       limits:

--- a/charts/app-of-apps/values-production.yaml
+++ b/charts/app-of-apps/values-production.yaml
@@ -107,11 +107,11 @@ ckanHelmValues:
       enabled: true
     appResources:
       limits:
-        memory: 1Gi
+        memory: 3Gi
         cpu: 1
       requests:
-        memory: 512Mi
-        cpu: 250m
+        memory: 1Gi
+        cpu: 500m
   fetch:
     replicaCount: 1
     appResources:

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -102,11 +102,11 @@ ckanHelmValues:
       enabled: true
     appResources:
       limits:
-        memory: 1Gi
+        memory: 3Gi
         cpu: 1
       requests:
-        memory: 512Mi
-        cpu: 250m
+        memory: 1Gi
+        cpu: 500m
   fetch:
     replicaCount: 1
     appResources:


### PR DESCRIPTION

I have now increased memory limits for harvest-gather service because it keeps restarting.

Harvest-gather has 116+ restarts and keeps crashing. The memory limit was only 1Gi but the service needs more to process data.

## The following are changed:

- Production: memory 1Gi -> 3Gi 
- Staging: memory 1Gi -> 3Gi
- Also increased CPU requests from 250m to 500m in all places


The service was running out of memory and getting killed by Kubernetes. Higher limits mean it can do its job without crashing.

