### PR TITLE
Add second pod for datagovuk-find in integration

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -124,7 +124,7 @@ datagovukHelmValues:
         memory: 2Gi
       requests:
         memory: 1Gi
-    replicaCount: 1
+    replicaCount: 2
     args: ["bin/rails s -b 0.0.0.0 --pid /tmp/rails-server.pid"]
     config:
       googleTagManagerId: GTM-5WRWCH8X


### PR DESCRIPTION

Here now I have added a second pod for datagovuk-find in integration environment.


Integration only had 1 pod while production and staging have 2 pods. Need to match the setup so testing is the same as production.

## The following are changed

- Integration datagovuk-find: replicaCount 1 -> 2

## Current setup after this
- Production: 2 pods
- Staging: 2 pods
- Integration: 2 pods (now added)
