### PR TITLE
Relabel datagovuk metrics

### DIFF
--- a/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
+++ b/charts/datagovuk/templates/datagovuk/datagovuk-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: http
               containerPort: 8000
             - name: metrics
-              containerPort: {{ .Values.datagovuk.monitoring.metricsPort }}
+              containerPort: {{ .Values.monitoring.metricsPort }}
           env:
              {{ include "datagovuk.environment-variables" . | nindent 12 }}
             - name: FEATURE_FLAGS_ENABLED

--- a/charts/datagovuk/templates/datagovuk/podmonitor.yaml
+++ b/charts/datagovuk/templates/datagovuk/podmonitor.yaml
@@ -15,5 +15,26 @@ spec:
       app: {{ .Release.Name }}-datagovuk
   podMetricsEndpoints:
   - port: metrics
+    metricRelabelings:
+    - action: replace
+      sourceLabels: ["__name__"]
+      targetLabel: __name__
+      regex: django_http_responses_total_by_status_total
+      replacement: http_requests_total
+    - action: replace
+      sourceLabels: ["__name__"]
+      targetLabel: __name__
+      regex: django_http_requests_latency_including_middlewares_seconds_bucket
+      replacement: http_request_duration_seconds_bucket
+    - action: replace
+      sourceLabels: ["__name__"]
+      targetLabel: __name__
+      regex: django_http_requests_latency_including_middlewares_seconds_sum
+      replacement: http_request_duration_seconds_sum
+    - action: replace
+      sourceLabels: ["__name__"]
+      targetLabel: __name__
+      regex: django_http_requests_latency_including_middlewares_seconds_count
+      replacement: http_request_duration_seconds_count
 {{- end }}
 {{- end }}

--- a/charts/datagovuk/values.yaml
+++ b/charts/datagovuk/values.yaml
@@ -21,7 +21,6 @@ datagovuk:
     annotations:
   monitoring:
     enabled: false
-    metricsPort: 80
   config:
     basicAuthNameSecretKeyRef:
       name: datagovuk


### PR DESCRIPTION
The django metric labels have been relabelled so that we can compare the NDL dashboard metrics between the Find and datagovuk app.

Note that this is dependent on the datagovuk metrics port being set to 9394

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/727?selectedIssue=DGUK-912