### PR TITLE
[DGUK-927] Directory smoke tests

### DIFF
--- a/charts/datagovuk/templates/cronjobs/e2e_fixtures_create.yaml
+++ b/charts/datagovuk/templates/cronjobs/e2e_fixtures_create.yaml
@@ -30,8 +30,6 @@ spec:
               command: [ python, manage.py, e2e_fixtures, --create ]
               env:
                 {{ include "datagovuk.environment-variables" . | nindent 16 }}
-                - name: FEATURE_FLAGS_ENABLED
-                  value: ""
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp

--- a/charts/datagovuk/templates/cronjobs/e2e_fixtures_create.yaml
+++ b/charts/datagovuk/templates/cronjobs/e2e_fixtures_create.yaml
@@ -1,0 +1,66 @@
+{{- if (ne .Values.environment "production") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-e2e-fixtures-create
+  annotations:
+    argocd.argoproj.io/ignore-healthcheck: "true"
+  labels:
+    app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+spec:
+  schedule: "0 10 * * 0" # Run at 10AM; after the solr-index-clear cronjob runs at 8AM
+  suspend: {{ .Values.suspendCronJobs }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      name: {{ .Release.Name }}-e2e-fixtures-create
+      labels:
+        app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+    spec:
+      template:
+        metadata:
+          name: {{ .Release.Name }}-e2e-fixtures-create
+          labels:
+            app.kubernetes.io/arch: {{ default "amd64" .Values.arch }}
+        spec:
+          containers:
+            - name: datagovuk
+              image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "datagovuk" "files" $.Files) }}'
+              imagePullPolicy: Always
+              command: [ python, manage.py, e2e_fixtures, --create ]
+              env:
+                {{ include "datagovuk.environment-variables" . | nindent 16 }}
+                - name: FEATURE_FLAGS_ENABLED
+                  value: ""
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: app-tmp
+                  mountPath: /app/tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 900
+            runAsGroup: 900
+            fsGroup: 900
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: app-tmp
+              emptyDir: {}
+          {{- if eq "arm64" .Values.arch }}
+          tolerations:
+            - key: arch
+              operator: Equal
+              value: {{ .Values.arch }}
+              effect: NoSchedule
+          nodeSelector:
+            kubernetes.io/arch: {{ .Values.arch }}
+          {{- end }}
+{{- end }}


### PR DESCRIPTION
Add a cronjob for datagovuk python app; run `python manage.py e2e_fixtures --create` every Sunday at 10AM.

This runs the management command added in the companion PR here; https://github.com/alphagov/datagovuk/pull/322
The management command sets up publishers/datasets in the solr index which the end to end tests depend upon.  This enables our smoke tests to be able to run successfully in integration/staging environments.